### PR TITLE
Gate test teardown on full session exit to fix state-file cleanup race

### DIFF
--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -40,14 +40,18 @@ func terminateTestManager(tb testing.TB, m *Manager) {
 	for _, s := range sessions {
 		terminateTestSession(s, syscall.SIGTERM)
 	}
-	if waitForTestSessionsExited(sessions, time.Second) {
+	if waitForTestSessionsExited(sessions, 2*time.Second) {
 		return
 	}
 
 	for _, s := range sessions {
 		terminateTestSession(s, syscall.SIGKILL)
 	}
-	if !waitForTestSessionsExited(sessions, time.Second) {
+	// Generous budget: exitDone only closes once waitForExit fully returns,
+	// which includes cleanupDescendants — it re-scans for surviving child
+	// processes with up to 5x1s sleeps before SIGKILLing them. A session that
+	// spawned a background job can therefore take several seconds to drain.
+	if !waitForTestSessionsExited(sessions, 10*time.Second) {
 		tb.Errorf("timed out waiting for test sessions to exit")
 	}
 }
@@ -59,24 +63,32 @@ func terminateTestSession(s *Session, signal syscall.Signal) {
 	syscall.Kill(-s.cmd.Process.Pid, signal) //nolint:errcheck
 }
 
+// waitForTestSessionsExited blocks until every session has fully torn down,
+// i.e. its waitForExit goroutine has returned (exitDone closed) after running
+// the trailing onSessionChanged/state-file write. Waiting on exitDone rather
+// than s.Exited() is what keeps cleanup from racing t.TempDir's RemoveAll: a
+// late state-file write must not land in the temp dir after teardown returns.
 func waitForTestSessionsExited(sessions []*Session, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
-	for {
-		allExited := true
-		for _, s := range sessions {
-			if s != nil && !s.Exited() {
-				allExited = false
-				break
-			}
+	for _, s := range sessions {
+		if s == nil {
+			continue
 		}
-		if allExited {
-			return true
+		// Fast path: already fully torn down, avoid racing a 0-duration timer.
+		select {
+		case <-s.exitDone:
+			continue
+		default:
 		}
-		if time.Now().After(deadline) {
+		timer := time.NewTimer(time.Until(deadline))
+		select {
+		case <-s.exitDone:
+			timer.Stop()
+		case <-timer.C:
 			return false
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
+	return true
 }
 
 func TestManager_CreateAndList(t *testing.T) {

--- a/session/session.go
+++ b/session/session.go
@@ -46,6 +46,7 @@ type Session struct {
 
 	pumpDone    chan struct{} // closed when pump goroutine exits; barrier for vte.Close
 	drainDone   chan struct{} // closed by drainVTE on exit; awaited before vte.Close so no reader races with close
+	exitDone    chan struct{} // closed when waitForExit fully returns, after the final onSessionChanged/state-file write
 	cleanup     chan struct{}
 	cleanupOnce sync.Once
 }
@@ -78,6 +79,7 @@ func newSession(id string, cols, rows uint16, env []string, mgr *Manager) (*Sess
 		rows:      rows,
 		pumpDone:  make(chan struct{}),
 		drainDone: make(chan struct{}),
+		exitDone:  make(chan struct{}),
 		cleanup:   make(chan struct{}),
 	}
 
@@ -356,6 +358,12 @@ func (s *Session) pump() {
 // early (before descendant cleanup) to reject new attaches; pump sets it
 // again idempotently in its error-path critical section.
 func (s *Session) waitForExit() {
+	// exitDone signals that the entire exit-handling sequence — including the
+	// final onSessionChanged/state-file write below — has completed. Teardown
+	// (e.g. test cleanup) waits on this rather than s.exited, which is set
+	// early and does not cover the trailing state-file write.
+	defer close(s.exitDone)
+
 	exitCode := 0
 	if err := s.cmd.Wait(); err != nil {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {


### PR DESCRIPTION
TestStateFile_ConcurrentWritesNoStaleOverwrite flaked in CI with:

  TempDir RemoveAll cleanup: unlinkat .../001: directory not empty

The test's assertions passed; the failure was in t.TempDir()'s RemoveAll racing a post-exit state-file write. waitForExit sets s.exited = true early (to reject new attaches) but writes the state file later in the same goroutine, after cleanupDescendants and PTY/VTE teardown. Test teardown gated on s.Exited(), so it returned while that trailing writeStateFile was still in flight; the write dropped sessions.json.tmp back into the temp dir mid-delete. It only manifested under CI scheduling, hence the local-pass / CI-fail split.

Add an exitDone channel, closed when waitForExit fully returns (after the final onSessionChanged/state-file write), and have waitForTestSessionsExited wait on it instead of polling s.Exited(). This guarantees no session goroutine touches the temp dir after teardown returns. exitDone follows the existing pumpDone/drainDone lifecycle-signal pattern.

Because exitDone now waits through cleanupDescendants (up to 5x1s descendant reaping), raise the teardown budget so sessions that spawned background jobs have time to drain.