### PR TITLE
Adding add-cidr config option to explicitly allow unsafe IPs in proxy

### DIFF
--- a/cmd/control_test.go
+++ b/cmd/control_test.go
@@ -114,6 +114,7 @@ func TestControlClient_Config(t *testing.T) {
 		AllowHTTP: []string{"a.com:443", "b.com:443"},
 		AllowDNS:  []string{"c.com"},
 		BlockCIDR: []string{"10.0.0.0/8"},
+		AllowCIDR: []string{"100.64.0.0/10"},
 	}
 
 	httpAL, err := proxy.NewHTTPAllowlist(nil)
@@ -128,6 +129,7 @@ func TestControlClient_Config(t *testing.T) {
 	assert.Equal(t, []string{"a.com:443", "b.com:443"}, cfg.AllowHTTP)
 	assert.Equal(t, []string{"c.com"}, cfg.AllowDNS)
 	assert.Equal(t, []string{"10.0.0.0/8"}, cfg.BlockCIDR)
+	assert.Equal(t, []string{"100.64.0.0/10"}, cfg.AllowCIDR)
 }
 
 func TestControlClient_AllowHTTP(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type GlobalConfig struct {
 	AllowHTTP []string `koanf:"allow-http"`
 	AllowDNS  []string `koanf:"allow-dns"`
 	BlockCIDR []string `koanf:"block-cidr"`
+	AllowCIDR []string `koanf:"allow-cidr"`
 }
 
 type ProjectConfig struct {
@@ -46,6 +47,7 @@ type MergedConfig struct {
 	AllowHTTP      []string `json:"allow-http"`
 	AllowDNS       []string `json:"allow-dns"`
 	BlockCIDR      []string `json:"block-cidr"`
+	AllowCIDR      []string `json:"allow-cidr"`
 	AllowHostPorts []int    `json:"allow-host-ports"`
 	ProxyIP        string   `json:"proxy-ip,omitempty"`
 	HostGateway    string   `json:"host-gateway,omitempty"`
@@ -122,6 +124,7 @@ func (c *Config) Merge(cliAllow []string, cliPresets []string) (MergedConfig, er
 		AllowHTTP:      allowHTTP,
 		AllowDNS:       allowDNS,
 		BlockCIDR:      c.Global.BlockCIDR,
+		AllowCIDR:      c.Global.AllowCIDR,
 		AllowHostPorts: c.Project.AllowHostPorts,
 	}, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,8 @@ allow-dns:
   - internal.example.com
 block-cidr:
   - 203.0.113.0/24
+allow-cidr:
+  - 100.64.0.0/10
 `), 0o644)
 
 		projectFile := filepath.Join(projectDir, "network.yaml")
@@ -47,6 +49,7 @@ allow-http:
 		}
 		assert.Contains(t, merged.AllowDNS, "internal.example.com")
 		assert.Contains(t, merged.BlockCIDR, "203.0.113.0/24")
+		assert.Contains(t, merged.AllowCIDR, "100.64.0.0/10")
 	})
 
 	t.Run("CLI overrides add to merged config", func(t *testing.T) {

--- a/proxy/cidr.go
+++ b/proxy/cidr.go
@@ -14,27 +14,50 @@ var defaultBlockedCIDRs = []string{
 }
 
 type CIDRBlocker struct {
-	nets []*net.IPNet
+	blockNets []*net.IPNet
+	allowNets []*net.IPNet
 }
 
-func NewCIDRBlocker(extra []string) *CIDRBlocker {
-	all := make([]string, 0, len(defaultBlockedCIDRs)+len(extra))
-	all = append(all, defaultBlockedCIDRs...)
-	all = append(all, extra...)
+func NewCIDRBlocker(block, allow []string) *CIDRBlocker {
+	blocked := make([]string, 0, len(defaultBlockedCIDRs)+len(block))
+	blocked = append(blocked, defaultBlockedCIDRs...)
+	blocked = append(blocked, block...)
 
-	nets := make([]*net.IPNet, 0, len(all))
-	for _, cidr := range all {
+	blockNets := parseCIDRs(blocked)
+	allowNets := parseCIDRs(allow)
+
+	return &CIDRBlocker{
+		blockNets: blockNets,
+		allowNets: allowNets,
+	}
+}
+
+func parseCIDRs(cidrs []string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			continue
 		}
 		nets = append(nets, ipNet)
 	}
-	return &CIDRBlocker{nets: nets}
+	return nets
+}
+
+func (b *CIDRBlocker) IsAllowed(ip net.IP) bool {
+	for _, n := range b.allowNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *CIDRBlocker) IsBlocked(ip net.IP) bool {
-	for _, n := range b.nets {
+	if b.IsAllowed(ip) {
+		return false
+	}
+	for _, n := range b.blockNets {
 		if n.Contains(ip) {
 			return true
 		}

--- a/proxy/cidr_test.go
+++ b/proxy/cidr_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCIDRBlocker(t *testing.T) {
-	blocker := NewCIDRBlocker(nil)
+	blocker := NewCIDRBlocker(nil, nil)
 
 	tests := []struct {
 		name string
@@ -41,7 +41,7 @@ func TestCIDRBlocker(t *testing.T) {
 }
 
 func TestCIDRBlockerCustomRanges(t *testing.T) {
-	blocker := NewCIDRBlocker([]string{"203.0.113.0/24"})
+	blocker := NewCIDRBlocker([]string{"203.0.113.0/24"}, nil)
 
 	tests := []struct {
 		name string
@@ -58,6 +58,105 @@ func TestCIDRBlockerCustomRanges(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ip := net.ParseIP(tt.ip)
 			assert.Equal(t, tt.want, blocker.IsBlocked(ip), "IsBlocked(%s)", tt.ip)
+		})
+	}
+}
+
+func TestCIDRBlockerAllowCIDR(t *testing.T) {
+	blocker := NewCIDRBlocker(nil, []string{"10.0.0.0/24"})
+
+	tests := []struct {
+		name        string
+		ip          string
+		wantBlocked bool
+	}{
+		{"in allow range, normally blocked", "10.0.0.5", false},
+		{"in allow range /24 boundary", "10.0.0.255", false},
+		{"just outside allow range", "10.0.1.1", true},
+		{"other private IP still blocked", "192.168.1.1", true},
+		{"public IP allowed (not in blocked ranges)", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "invalid test IP: %s", tt.ip)
+			assert.Equal(t, tt.wantBlocked, blocker.IsBlocked(ip), "IsBlocked(%s)", tt.ip)
+			if !tt.wantBlocked && tt.name == "in allow range, normally blocked" {
+				assert.True(t, blocker.IsAllowed(ip), "IsAllowed(%s) should be true for allowed CIDR", tt.ip)
+			}
+		})
+	}
+}
+
+func TestCIDRBlockerAllowOverridesBlock(t *testing.T) {
+	blocker := NewCIDRBlocker(
+		[]string{"172.16.0.0/12"},
+		[]string{"172.16.0.0/24"},
+	)
+
+	tests := []struct {
+		name        string
+		ip          string
+		wantBlocked bool
+	}{
+		{"in both block and allow, allow wins", "172.16.0.5", false},
+		{"in block but outside allow", "172.20.0.1", true},
+		{"in default block, not in custom block", "10.0.0.1", true},
+		{"in default allow (public)", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "invalid test IP: %s", tt.ip)
+			assert.Equal(t, tt.wantBlocked, blocker.IsBlocked(ip), "IsBlocked(%s)", tt.ip)
+		})
+	}
+}
+
+func TestCIDRBlockerAllowEmpty(t *testing.T) {
+	blocker := NewCIDRBlocker(nil, nil)
+
+	tests := []struct {
+		name        string
+		ip          string
+		wantBlocked bool
+	}{
+		{"private blocked", "10.0.0.1", true},
+		{"public allowed", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "invalid test IP: %s", tt.ip)
+			assert.Equal(t, tt.wantBlocked, blocker.IsBlocked(ip), "IsBlocked(%s)", tt.ip)
+		})
+	}
+}
+
+func TestCIDRBlockerInvalidCIDRs(t *testing.T) {
+	blocker := NewCIDRBlocker(
+		[]string{"not-a-cidr", "10.0.0.0/33"},
+		[]string{"also-invalid", "192.168.0.0/24"},
+	)
+
+	tests := []struct {
+		name        string
+		ip          string
+		wantBlocked bool
+	}{
+		{"valid allow CIDR", "192.168.0.1", false},
+		{"default still blocked", "10.0.0.1", true},
+		{"public allowed", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "invalid test IP: %s", tt.ip)
+			assert.Equal(t, tt.wantBlocked, blocker.IsBlocked(ip), "IsBlocked(%s)", tt.ip)
 		})
 	}
 }

--- a/proxy/dns_test.go
+++ b/proxy/dns_test.go
@@ -13,7 +13,7 @@ import (
 func TestDNSServer(t *testing.T) {
 	al, err := NewDNSAllowlist([]string{"allowed.example.com", "dnsonly.example.com"})
 	require.NoError(t, err)
-	blocker := NewCIDRBlocker(nil)
+	blocker := NewCIDRBlocker(nil, nil)
 	log := NewLogBuffer(100)
 
 	srv := NewDNSServer(al, blocker, log, "8.8.8.8:53")
@@ -72,7 +72,7 @@ func TestDNSServer(t *testing.T) {
 func TestDNSHostVibepit(t *testing.T) {
 	al, err := NewDNSAllowlist(nil)
 	require.NoError(t, err)
-	blocker := NewCIDRBlocker(nil)
+	blocker := NewCIDRBlocker(nil, nil)
 	log := NewLogBuffer(100)
 
 	proxyIP := net.ParseIP("10.42.0.2")

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -19,7 +19,7 @@ func TestHTTPProxy(t *testing.T) {
 	t.Run("blocks plain HTTP by default", func(t *testing.T) {
 		al, err := NewHTTPAllowlist([]string{"httpbin.org:443"})
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 
@@ -82,7 +82,7 @@ func TestHTTPProxy(t *testing.T) {
 	t.Run("blocks disallowed domain for plain HTTP", func(t *testing.T) {
 		al, err := NewHTTPAllowlist([]string{"allowed.example.com:443"})
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 
@@ -104,7 +104,7 @@ func TestHTTPProxy(t *testing.T) {
 	t.Run("logs blocked request", func(t *testing.T) {
 		al, err := NewHTTPAllowlist([]string{"httpbin.org:443"})
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 
@@ -132,7 +132,7 @@ func TestHTTPProxy(t *testing.T) {
 	t.Run("blocks when resolver errors with no addresses", func(t *testing.T) {
 		al, err := NewHTTPAllowlist([]string{"example.com:443"})
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 		p.resolver = &net.Resolver{
@@ -167,7 +167,7 @@ func TestHTTPProxyHostVibepit(t *testing.T) {
 	t.Run("auto-allows host.vibepit for configured port", func(t *testing.T) {
 		al, err := NewHTTPAllowlist(nil)
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 		p.SetHostVibepit(backendURL.Host, []int{backendPortInt})
@@ -190,7 +190,7 @@ func TestHTTPProxyHostVibepit(t *testing.T) {
 	t.Run("blocks host.vibepit for unconfigured port", func(t *testing.T) {
 		al, err := NewHTTPAllowlist(nil)
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 		p.SetHostVibepit(backendURL.Host, []int{9999})
@@ -211,7 +211,7 @@ func TestHTTPProxyHostVibepit(t *testing.T) {
 	t.Run("host.vibepit allowed via allowlist bypasses CIDR", func(t *testing.T) {
 		al, err := NewHTTPAllowlist([]string{"host.vibepit:" + backendPortStr})
 		require.NoError(t, err)
-		blocker := NewCIDRBlocker(nil)
+		blocker := NewCIDRBlocker(nil, nil)
 		log := NewLogBuffer(100)
 		p := NewHTTPProxy(al, blocker, log, DefaultUpstreamDNS)
 		p.SetHostVibepit(backendURL.Host, nil)

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -29,6 +29,7 @@ type ProxyConfig struct {
 	AllowHTTP      []string `json:"allow-http"`
 	AllowDNS       []string `json:"allow-dns"`
 	BlockCIDR      []string `json:"block-cidr"`
+	AllowCIDR      []string `json:"allow-cidr"`
 	Upstream       string   `json:"upstream"`
 	AllowHostPorts []int    `json:"allow-host-ports"`
 	ProxyIP        string   `json:"proxy-ip"`
@@ -71,7 +72,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("allow-dns: %w", err)
 	}
-	cidr := NewCIDRBlocker(s.config.BlockCIDR)
+	cidr := NewCIDRBlocker(s.config.BlockCIDR, s.config.AllowCIDR)
 	log := NewLogBuffer(LogBufferCapacity)
 
 	httpProxy := NewHTTPProxy(allowlist, cidr, log, s.config.Upstream)


### PR DESCRIPTION
Prior to this PR, if you want to proxy to a machine e.g. in your local LAN and you have private IPs - which is often the case when you're behind a home router that NATs - you were not able to do so because of the `defaultBlockedCIDRs`.

This PR adds a `allow-cidr` option similar to `block-cidr` that allows you to specify IPs that are explicitly allowed, solving the mentioned problem.

This does not solve that DNS lookup for hostnames in your LAN might not work and you'll have to reference machines in your LAN by IP. I'll try to solve this in a follow up PR.