### PR TITLE
Add docs.github.com to allowed hosts in presets

### DIFF
--- a/docs/content/reference/presets.md
+++ b/docs/content/reference/presets.md
@@ -124,6 +124,7 @@ camo.githubusercontent.com:443
 gist.github.com:443
 release-assets.githubusercontent.com:443
 patch-diff.githubusercontent.com:443
+docs.github.com:443
 ```
 
 ### `vcs-other`

--- a/proxy/presets.yaml
+++ b/proxy/presets.yaml
@@ -87,6 +87,7 @@
     - "gist.github.com:443"
     - "release-assets.githubusercontent.com:443"
     - "patch-diff.githubusercontent.com:443"
+    - "docs.github.com:443"
 
 - name: "vcs-other"
   group: "Infrastructure"


### PR DESCRIPTION
Add docs.github.com to the list of allowed hosts.