### PR TITLE
sshd: pass raw PTY output through SSH without \n->\r\n rewrite

### DIFF
--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -375,6 +375,73 @@ ready:
 	c2.Close()
 }
 
+// TestSession_ReplayUsesCRLF verifies that the reattach replay terminates every
+// line with CRLF, not a bare LF. The replay reconstructs screen state for a
+// terminal in raw mode (no \n->\r\n translation), so a bare \n would move down
+// without returning to column 0 and stair-step the reconstructed screen — the
+// regression seen with raw-mode TUIs (agy) after the SSH layer stopped cooking
+// newlines. Live PTY output is intentionally left raw; only the replay is
+// normalized.
+func TestSession_ReplayUsesCRLF(t *testing.T) {
+	m := testManager(t, 50)
+	s, err := m.Create(80, 24, nil)
+	require.NoError(t, err)
+
+	c1 := s.Attach(80, 24)
+	// Closing c1 on cleanup unblocks the reader goroutine below if the read
+	// loop bails via t.Fatal — its c1.Read would otherwise block forever.
+	t.Cleanup(func() { c1.Close() })
+	_, err = c1.Write([]byte("printf 'AAA\\nBBB\\nCCC\\n'\n"))
+	require.NoError(t, err)
+
+	buf := make([]byte, 65536)
+	deadline := time.After(3 * time.Second)
+	var collected strings.Builder
+	for {
+		readDone := make(chan int, 1)
+		go func() {
+			n, _ := c1.Read(buf)
+			readDone <- n
+		}()
+		select {
+		case n := <-readDone:
+			collected.Write(buf[:n])
+			if strings.Contains(collected.String(), "CCC") {
+				goto ready
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for output")
+		}
+	}
+ready:
+	c1.Close()
+
+	// Reattach. Attach delivers the replay as a single c.deliver() under s.mu
+	// before the client joins s.clients, so it is the first chunk and is not
+	// interleaved with live output; one large Read captures all of it.
+	c2 := s.Attach(80, 24)
+	n, err := c2.Read(buf)
+	require.NoError(t, err)
+	require.Greater(t, n, 0, "should receive replay output")
+	replay := buf[:n]
+	c2.Close()
+
+	// Tripwire for the single-chunk assumption: the replay ends with the
+	// cursor-position escape Attach appends last. If replay delivery is ever
+	// split so this Read holds only a prefix, this fails loudly instead of
+	// letting a bare \n in a later, unchecked chunk slip past the scan below.
+	require.Regexp(t, `\x1b\[[0-9]+;[0-9]+H$`, string(replay),
+		"expected the complete replay (ending in a cursor-position escape) in one Read")
+
+	require.Contains(t, string(replay), "\r\n", "replay should use CRLF line breaks")
+	for i, b := range replay {
+		if b == '\n' {
+			require.Truef(t, i > 0 && replay[i-1] == '\r',
+				"replay has a bare \\n at offset %d (stair-steps on a raw terminal)", i)
+		}
+	}
+}
+
 // TestSession_VTEDoesNotDropUnderBurst verifies that a large burst of shell
 // output does not cause the VT emulator state to desync from reality.
 // Historically, pump fed the emulator through a 1024-slot async channel and

--- a/session/session.go
+++ b/session/session.go
@@ -188,6 +188,13 @@ func (s *Session) Attach(cols, rows uint16) *Client {
 			// CSI cursor-position (ESC[<row>;<col>H) - 1-indexed; cursorPos is 0-indexed.
 			replay = append(replay, fmt.Sprintf("\033[%d;%dH", cursorPos.Y+1, cursorPos.X+1)...)
 		}
+		// The replay is reconstructed screen content (scrollback + VTE render)
+		// whose line breaks are bare \n. The connected terminal is in raw mode,
+		// so each line must return to column 0 explicitly — emit CRLF. Live PTY
+		// output is deliberately not rewritten (a raw-mode TUI's bare \n means
+		// "down, keep column" and must reach the client intact); only this
+		// vibed-generated replay needs newline semantics.
+		replay = ToCRLF(replay)
 		if len(replay) > 0 {
 			c.deliver(replay)
 		}
@@ -447,6 +454,21 @@ func (s *Session) expireTombstone() {
 
 func (s *Session) waitForCleanup() {
 	<-s.cleanup
+}
+
+// ToCRLF normalizes bare \n to \r\n without doubling carriage returns on
+// content that already uses \r\n. It is the single source of truth for cooking
+// vibed-generated output bound for a raw-mode terminal that does not translate
+// \n itself: the reattach replay below, and sshd's selector/stderr writers
+// (which wrap it in an io.Writer). Live PTY bytes are deliberately never run
+// through it — a raw-mode TUI's bare \n must reach the client intact.
+//
+// Note: this is a whole-buffer transform. A streaming caller that can split a
+// \r\n across two Write calls would double the CR; current callers emit bare
+// \n (the collapse step is defensive), so that boundary case never arises.
+func ToCRLF(b []byte) []byte {
+	b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+	return bytes.ReplaceAll(b, []byte("\n"), []byte("\r\n"))
 }
 
 // renderVTEScrollback renders the VTE emulator's scrollback buffer (lines

--- a/sshd/rawsession.go
+++ b/sshd/rawsession.go
@@ -1,0 +1,221 @@
+package sshd
+
+import (
+	"context"
+	"io"
+
+	charmssh "github.com/charmbracelet/ssh"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/bernd/vibepit/session"
+)
+
+// rawSession adapts a raw gossh.Channel to the small surface the PTY/exec
+// handlers need. It deliberately bypasses charmbracelet/ssh's emulated-PTY
+// session, whose writer rewrites every \n to \r\n (see pty.go ptyWriter) and
+// corrupts raw-mode TUI output. Writes here go straight to the SSH channel, so
+// the session PTY's own termios is the sole authority on line endings.
+//
+// Embedding gossh.Channel provides Read, Write, Close, CloseWrite, Stderr, and
+// SendRequest with no transformation; rawSession adds the session metadata
+// (env, command, pty) and an Exit that mirrors charmssh's exit-status behavior.
+type rawSession struct {
+	gossh.Channel
+
+	ctx    context.Context //nolint:containedctx // mirrors charmssh.Session.Context lifetime
+	env    []string
+	rawCmd string
+
+	term  string
+	winch chan charmssh.Window
+}
+
+// Environ returns a copy of the environment requested by the client via "env"
+// requests. A copy keeps callers (which append to the result) from mutating the
+// session's backing slice.
+func (s *rawSession) Environ() []string {
+	out := make([]string, len(s.env))
+	copy(out, s.env)
+	return out
+}
+
+// Context returns the connection-scoped context (canceled on disconnect).
+func (s *rawSession) Context() context.Context { return s.ctx }
+
+// RawCommand returns the command from an "exec" request, or "" for a shell.
+func (s *rawSession) RawCommand() string { return s.rawCmd }
+
+// Exit sends the SSH exit-status and closes the channel, matching the semantics
+// the handlers previously relied on from charmssh.Session.Exit.
+func (s *rawSession) Exit(code int) error {
+	payload := struct{ Status uint32 }{Status: uint32(code)}             //nolint:gosec
+	s.Channel.SendRequest("exit-status", false, gossh.Marshal(&payload)) //nolint:errcheck
+	return s.Channel.Close()
+}
+
+// hasPty reports whether the client requested a PTY for this session.
+func (s *rawSession) hasPty() bool { return s.winch != nil }
+
+// Stderr returns the session's diagnostic stream. With a PTY the connected
+// terminal is in raw mode, so vibed-generated messages written here (e.g. a
+// "create session" error) must use CRLF — without it they stair-step. This
+// mirrors charmbracelet/ssh's emulated-PTY Stderr, which cooked stderr only
+// when a PTY was present. Without a PTY (exec) the client terminal is cooked
+// and adds the CR itself, so stderr passes through raw.
+func (s *rawSession) Stderr() io.Writer {
+	if s.hasPty() {
+		return crlfWriter{w: s.Channel.Stderr()}
+	}
+	return s.Channel.Stderr()
+}
+
+// crlfWriter wraps a writer so vibed-generated output (the session selector,
+// PTY-session stderr) is CRLF-cooked for a raw-mode client. It delegates the
+// transform to session.ToCRLF, the single source of truth shared with the
+// reattach replay. Always reports len(p) consumed so callers see a full write.
+type crlfWriter struct{ w io.Writer }
+
+func (c crlfWriter) Write(p []byte) (int, error) {
+	if _, err := c.w.Write(session.ToCRLF(p)); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// SSH request payloads (RFC 4254 §6).
+type ptyReqPayload struct {
+	Term                         string
+	Columns, Rows, WidthPx, HtPx uint32
+	Modes                        string
+}
+
+type winChPayload struct {
+	Columns, Rows, WidthPx, HtPx uint32
+}
+
+type envPayload struct{ Name, Value string }
+
+type execPayload struct{ Command string }
+
+// handleSessionChannel is registered as the "session" ChannelHandler, replacing
+// charmssh's DefaultSessionHandler so output is never run through the emulated-
+// PTY \n->\r\n writer. charmssh still owns TCP accept, the SSH handshake,
+// public-key auth, idle timeout, and connection-level global requests; only the
+// per-session channel I/O is handled here against the raw gossh.Channel.
+func (s *Server) handleSessionChannel(_ *charmssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx charmssh.Context) {
+	ch, reqs, err := newChan.Accept()
+	if err != nil {
+		return
+	}
+
+	sess := &rawSession{Channel: ch, ctx: ctx}
+	var initialWin charmssh.Window
+	dispatched := false
+
+	for req := range reqs {
+		switch req.Type {
+		case "pty-req":
+			if dispatched || sess.winch != nil {
+				// At most one PTY per session. A later pty-req would replace
+				// sess.winch and orphan the resize goroutine's channel (never
+				// closed → leaked goroutine).
+				replyReq(req, false)
+				continue
+			}
+			var p ptyReqPayload
+			if !unmarshalReq(req, &p) {
+				continue
+			}
+			sess.term = p.Term
+			initialWin = charmssh.Window{Width: int(p.Columns), Height: int(p.Rows)} //nolint:gosec
+			// Buffered so a window-change never blocks the request loop; the
+			// resize consumer drains it and only the latest size matters.
+			sess.winch = make(chan charmssh.Window, 1)
+			replyReq(req, true)
+
+		case "window-change":
+			var p winChPayload
+			if err := gossh.Unmarshal(req.Payload, &p); err != nil || sess.winch == nil {
+				replyReq(req, false)
+				continue
+			}
+			win := charmssh.Window{Width: int(p.Columns), Height: int(p.Rows)} //nolint:gosec
+			// Coalesce: drop any stale pending size, then enqueue the latest.
+			select {
+			case <-sess.winch:
+			default:
+			}
+			select {
+			case sess.winch <- win:
+			default:
+			}
+			replyReq(req, true)
+
+		case "env":
+			if dispatched {
+				// Environment must be set before shell/exec. Rejecting late env
+				// avoids racing the dispatched handler goroutine's read of
+				// sess.env (only writes before the go statement are ordered).
+				replyReq(req, false)
+				continue
+			}
+			var p envPayload
+			if !unmarshalReq(req, &p) {
+				continue
+			}
+			sess.env = append(sess.env, p.Name+"="+p.Value)
+			replyReq(req, true)
+
+		case "shell", "exec":
+			if dispatched {
+				replyReq(req, false)
+				continue
+			}
+			if req.Type == "exec" {
+				var p execPayload
+				if !unmarshalReq(req, &p) {
+					continue
+				}
+				sess.rawCmd = p.Command
+			}
+			dispatched = true
+			replyReq(req, true)
+			// Dispatch on PTY presence, mirroring the original
+			// isPty ? handlePTYSession : handleExecSession logic. A shell
+			// without a PTY falls through to handleExecSession, which reports
+			// "no command specified" as before.
+			if sess.hasPty() {
+				go s.handlePTYSession(sess, initialWin.Width, initialWin.Height, sess.winch)
+			} else {
+				go s.handleExecSession(sess)
+			}
+
+		default:
+			// signal, break, subsystem, xon-xoff, etc. — unsupported.
+			replyReq(req, false)
+		}
+	}
+
+	// The channel closed (session ended): stop the resize consumer.
+	if sess.winch != nil {
+		close(sess.winch)
+	}
+}
+
+func replyReq(req *gossh.Request, ok bool) {
+	if req.WantReply {
+		req.Reply(ok, nil) //nolint:errcheck
+	}
+}
+
+// unmarshalReq decodes an SSH request payload into dest, replying false to a
+// decode failure. It returns true on success; on false the caller continues to
+// the next request. window-change decodes inline because it pairs the decode
+// with a sess.winch precondition.
+func unmarshalReq(req *gossh.Request, dest any) bool {
+	if err := gossh.Unmarshal(req.Payload, dest); err != nil {
+		replyReq(req, false)
+		return false
+	}
+	return true
+}

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -113,8 +113,14 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 
 	srv := &charmssh.Server{
-		Handler:     s.handleSession,
 		IdleTimeout: idleConnectionTimeout,
+		// Override the "session" channel handler so session output is written
+		// to the raw gossh.Channel rather than charmssh's emulated-PTY writer,
+		// which rewrites \n to \r\n and corrupts raw-mode TUIs. charmssh still
+		// provides accept, handshake, auth, idle timeout, and global requests.
+		ChannelHandlers: map[string]charmssh.ChannelHandler{
+			"session": s.handleSessionChannel,
+		},
 		RequestHandlers: map[string]charmssh.RequestHandler{
 			sessionCountRequestType: func(_ charmssh.Context, _ *charmssh.Server, _ *gossh.Request) (bool, []byte) {
 				reply := s.sessionCount()
@@ -198,17 +204,8 @@ func (s *Server) sessionCount() SessionCountReply {
 	}
 }
 
-func (s *Server) handleSession(sess charmssh.Session) {
-	ptyReq, winCh, isPty := sess.Pty()
-	if isPty {
-		s.handlePTYSession(sess, ptyReq, winCh)
-	} else {
-		s.handleExecSession(sess)
-	}
-}
-
-func (s *Server) handlePTYSession(sess charmssh.Session, ptyReq charmssh.Pty, winCh <-chan charmssh.Window) {
-	cols, rows := clampPTYSize(ptyReq.Window.Width, ptyReq.Window.Height)
+func (s *Server) handlePTYSession(sess *rawSession, winCols, winRows int, winCh <-chan charmssh.Window) {
+	cols, rows := clampPTYSize(winCols, winRows)
 	mgr := s.sessions
 
 	s.mu.Lock()
@@ -238,7 +235,7 @@ func (s *Server) handlePTYSession(sess charmssh.Session, ptyReq charmssh.Pty, wi
 	// SSH clients typically don't forward COLORTERM. Fall back to the
 	// container's own value so the TUI can detect TrueColor support.
 	sshEnv := sess.Environ()
-	sshEnv = append(sshEnv, fmt.Sprintf("TERM=%s", ptyReq.Term))
+	sshEnv = append(sshEnv, fmt.Sprintf("TERM=%s", sess.term))
 	hasColorterm := slices.ContainsFunc(sshEnv, func(e string) bool {
 		return strings.HasPrefix(e, "COLORTERM=")
 	})
@@ -293,7 +290,15 @@ func (s *Server) handlePTYSession(sess charmssh.Session, ptyReq charmssh.Pty, wi
 		w := tui.NewWindow(header, screen)
 		p := tea.NewProgram(w,
 			tea.WithInput(cr),
-			tea.WithOutput(sess),
+			// Cook the selector's output to CRLF. BubbleTea writes straight to
+			// the raw SSH channel (no real PTY between), and with no TTY input
+			// it forces newline-mapping on — emitting bare \n for vertical
+			// motion while assuming the terminal turns it into CRLF. Since the
+			// SSH layer no longer rewrites \n->\r\n, vibed must cook this
+			// vibed-generated output itself or each redraw stair-steps. Live PTY
+			// output stays raw; only this synthetic UI is cooked (cf. the replay
+			// in session.ToCRLF and rawSession.Stderr).
+			tea.WithOutput(crlfWriter{w: sess}),
 			tea.WithEnvironment(sshEnv),
 			tea.WithColorProfile(colorprofile.Env(sshEnv)),
 			tea.WithWindowSize(int(cols), int(rows)),
@@ -396,7 +401,14 @@ func (s *Server) handlePTYSession(sess charmssh.Session, ptyReq charmssh.Pty, wi
 		}()
 	}
 
-	// Copy session output to SSH.
+	// Copy session output to SSH. This pump stays raw on purpose: it carries
+	// the live TUI's own bytes, whose bare \n means "down, keep column" and
+	// must reach the raw-mode client intact. The SSH layer no longer rewrites
+	// \n->\r\n, so any vibed-*generated* bytes sent to the client (banners,
+	// status lines, another tea.NewProgram, errors) must be CRLF-cooked at
+	// their source instead — wrap them in crlfWriter (see the selector at
+	// tea.WithOutput above, rawSession.Stderr, and session.ToCRLF). Do not cook
+	// here, or live output double-CRs.
 	done := make(chan struct{})
 	go func() {
 		io.Copy(sess, client) //nolint:errcheck
@@ -419,7 +431,7 @@ func (s *Server) handlePTYSession(sess charmssh.Session, ptyReq charmssh.Pty, wi
 	finishPTY(client, detachExitCode(reason))
 }
 
-func (s *Server) handleExecSession(sess charmssh.Session) {
+func (s *Server) handleExecSession(sess *rawSession) {
 	rawCmd := sess.RawCommand()
 	if rawCmd == "" {
 		fmt.Fprintln(sess.Stderr(), "no command specified") //nolint:errcheck
@@ -481,7 +493,7 @@ func (s *Server) handleExecSession(sess charmssh.Session) {
 // deadline, preventing IdleTimeout from killing silent long-running
 // commands. The goroutine exits when done is closed or when the session
 // context is canceled (e.g. real client disconnect).
-func execKeepalive(sess charmssh.Session, done <-chan struct{}) {
+func execKeepalive(sess *rawSession, done <-chan struct{}) {
 	ticker := time.NewTicker(execKeepaliveInterval)
 	defer ticker.Stop()
 	for {

--- a/sshd/server_test.go
+++ b/sshd/server_test.go
@@ -2,6 +2,7 @@ package sshd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/bernd/vibepit/keygen"
 	"github.com/bernd/vibepit/session"
+	charmssh "github.com/charmbracelet/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
@@ -530,4 +532,241 @@ func TestCleanExitViaSSH(t *testing.T) {
 		assert.Equalf(t, session.DetachNone, info.LastDetachReason,
 			"clean shell exit must not record a detach reason (session %s)", info.ID)
 	}
+}
+
+// TestRawNewlineNotCookedViaSSH guards against the SSH layer rewriting bare \n
+// to \r\n on session output. Full-screen TUIs (e.g. agy/Antigravity) switch the
+// PTY to raw mode and emit bare \n with relative cursor motion; an injected
+// carriage return snaps the cursor to column 0 and corrupts cursor-positioned
+// redraws.
+//
+// The session command disables output post-processing (stty -opost) and emits
+// a bare \n between two markers. The bytes the client receives must contain the
+// bare \n, never \r\n.
+func TestRawNewlineNotCookedViaSSH(t *testing.T) {
+	mgr := session.NewManager(50)
+	// Raw-mode emitter: clear opost so the session PTY itself does not cook the
+	// newline, then print MARK_A<bare-\n>MARK_B and linger briefly so the
+	// output is delivered before the shell exits.
+	mgr.Command = []string{"/bin/sh", "-c", "stty -opost; printf 'MARK_A\\nMARK_B'; sleep 0.3"}
+
+	client := dialTestServer(t, mgr)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	sess.Stdout = &buf
+	require.NoError(t, sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+	require.NoError(t, sess.Shell())
+
+	done := make(chan struct{})
+	go func() { sess.Wait(); close(done) }() //nolint:errcheck
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit in time")
+	}
+
+	got := buf.String()
+	require.Contains(t, got, "MARK_A", "expected emitter output in client stream")
+	require.NotContains(t, got, "MARK_A\r\nMARK_B",
+		"bare \\n was cooked to \\r\\n by the SSH layer")
+	require.Contains(t, got, "MARK_A\nMARK_B",
+		"client must receive the bare \\n exactly as the raw-mode app emitted it")
+}
+
+// syncBuf is a concurrency-safe buffer: the gossh client writes session output
+// from its own goroutine while the test polls the accumulated string.
+type syncBuf struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// dialTestServer starts an sshd Server backed by mgr on a loopback listener and
+// returns a connected, authenticated client. All resources are torn down via
+// t.Cleanup.
+func dialTestServer(t *testing.T, mgr *session.Manager) *gossh.Client {
+	t.Helper()
+	hostPriv, _, err := keygen.GenerateEd25519Keypair()
+	require.NoError(t, err)
+	clientPriv, clientPub, err := keygen.GenerateEd25519Keypair()
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() }) //nolint:errcheck
+
+	srv, err := NewServer(Config{
+		HostKeyPEM:    hostPriv,
+		AuthorizedKey: clientPub,
+		Sessions:      mgr,
+	})
+	require.NoError(t, err)
+	go srv.Serve(listener)            //nolint:errcheck
+	t.Cleanup(func() { srv.Close() }) //nolint:errcheck
+
+	signer, err := gossh.ParsePrivateKey(clientPriv)
+	require.NoError(t, err)
+	client, err := gossh.Dial("tcp", listener.Addr().String(), &gossh.ClientConfig{
+		User:            "code",
+		Auth:            []gossh.AuthMethod{gossh.PublicKeys(signer)},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() }) //nolint:errcheck
+	return client
+}
+
+// TestWindowChangeResizesPTYViaSSH drives an SSH window-change through the
+// custom session channel handler and asserts the session PTY is actually
+// resized. The session prints its terminal size on a loop; after the resize the
+// new dimensions appear. (gossh sends window-change as request order
+// term=rows,cols; stty prints "rows cols".)
+func TestWindowChangeResizesPTYViaSSH(t *testing.T) {
+	mgr := session.NewManager(50)
+	// Bounded poll so the size is reported deterministically (no WINCH-trap
+	// timing dependency) and the detached session self-terminates after ~10s.
+	mgr.Command = []string{"/bin/bash", "-c", "for i in $(seq 100); do stty size; sleep 0.1; done"}
+	client := dialTestServer(t, mgr)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	var out syncBuf
+	sess.Stdout = &out
+	require.NoError(t, sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+	require.NoError(t, sess.Shell())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "24 80")
+	}, 3*time.Second, 20*time.Millisecond, "expected initial 24x80 size")
+
+	require.NoError(t, sess.WindowChange(40, 100))
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "40 100")
+	}, 3*time.Second, 20*time.Millisecond, "expected resized 40x100 size after window-change")
+}
+
+// TestRejectsDuplicatePtyReqViaSSH verifies a second pty-req is rejected — the
+// guard that stops a later pty-req from orphaning the resize goroutine's
+// channel.
+func TestRejectsDuplicatePtyReqViaSSH(t *testing.T) {
+	mgr := session.NewManager(50)
+	client := dialTestServer(t, mgr)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	require.NoError(t, sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}),
+		"first pty-req should be accepted")
+	require.Error(t, sess.RequestPty("xterm", 30, 100, gossh.TerminalModes{}),
+		"second pty-req should be rejected")
+}
+
+// TestRejectsLateEnvViaSSH verifies an env request after shell dispatch is
+// rejected — the guard that avoids racing the handler goroutine's read of
+// sess.env.
+func TestRejectsLateEnvViaSSH(t *testing.T) {
+	mgr := session.NewManager(50)
+	mgr.Command = []string{"/bin/sh", "-c", "sleep 5"}
+	client := dialTestServer(t, mgr)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	require.NoError(t, sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+	require.NoError(t, sess.Setenv("EARLY", "1"), "env before shell should be accepted")
+	require.NoError(t, sess.Shell())
+	require.Error(t, sess.Setenv("LATE", "1"), "env after shell should be rejected")
+}
+
+// fakeChannel is a minimal gossh.Channel that captures stderr writes, for unit
+// testing rawSession's stderr handling without a live SSH connection.
+type fakeChannel struct{ stderr bytes.Buffer }
+
+func (f *fakeChannel) Read([]byte) (int, error)                       { return 0, io.EOF }
+func (f *fakeChannel) Write(p []byte) (int, error)                    { return len(p), nil }
+func (f *fakeChannel) Close() error                                   { return nil }
+func (f *fakeChannel) CloseWrite() error                              { return nil }
+func (f *fakeChannel) SendRequest(string, bool, []byte) (bool, error) { return true, nil }
+func (f *fakeChannel) Stderr() io.ReadWriter                          { return &f.stderr }
+
+// TestRawSessionStderrCRLF verifies that rawSession cooks stderr to CRLF only
+// when a PTY is present (the connected terminal is raw), mirroring charmssh's
+// emulated-PTY Stderr. Without a PTY the exec client cooks output itself, so
+// stderr must pass through raw.
+func TestRawSessionStderrCRLF(t *testing.T) {
+	withPty := &fakeChannel{}
+	sp := &rawSession{Channel: withPty, winch: make(chan charmssh.Window, 1)}
+	fmt.Fprint(sp.Stderr(), "create session: boom\n")
+	require.Equal(t, "create session: boom\r\n", withPty.stderr.String(),
+		"PTY-session stderr must use CRLF for a raw-mode client")
+
+	noPty := &fakeChannel{}
+	se := &rawSession{Channel: noPty}
+	fmt.Fprint(se.Stderr(), "no command specified\n")
+	require.Equal(t, "no command specified\n", noPty.stderr.String(),
+		"non-PTY (exec) stderr must pass through raw")
+}
+
+// TestSelectorOutputUsesCRLFViaSSH guards the session-selector render path. The
+// selector is a BubbleTea program written straight to the raw SSH channel (no
+// real PTY in between). BubbleTea v2 forces newline-mapping on when it has no
+// TTY input (cursed_renderer mapNl), so it emits bare \n for vertical motion
+// and assumes the terminal cooks it to CRLF. With the \n->\r\n rewrite removed
+// from the SSH layer, that assumption breaks and each per-tick redraw
+// stair-steps to the right unless vibed cooks the selector output itself.
+//
+// A pre-seeded detached session makes the selector appear on connect; the test
+// asserts every \n the client receives is preceded by \r.
+func TestSelectorOutputUsesCRLFViaSSH(t *testing.T) {
+	mgr := session.NewManager(50)
+	// Short-lived so the detached session self-terminates after the test; alive
+	// long enough that the selector lists it on connect.
+	mgr.Command = []string{"/bin/sh", "-c", "sleep 5"}
+	_, err := mgr.Create(80, 24, nil) // zero clients -> Detached -> selector shows
+	require.NoError(t, err)
+
+	client := dialTestServer(t, mgr)
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	var out syncBuf
+	sess.Stdout = &out
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}))
+	require.NoError(t, sess.Shell())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "\n")
+	}, 5*time.Second, 20*time.Millisecond, "selector should render a multi-line frame")
+
+	got := out.String()
+	for i := 0; i < len(got); i++ {
+		if got[i] == '\n' {
+			require.Truef(t, i > 0 && got[i-1] == '\r',
+				"selector output has a bare \\n at offset %d (stair-steps on a raw-mode client)", i)
+		}
+	}
+
+	stdin.Write([]byte("q")) //nolint:errcheck
 }


### PR DESCRIPTION
charmbracelet/ssh's emulated-PTY session writer rewrites every \n to \r\n. Full-screen TUIs (Claude Code, Codex, agy) put the PTY in raw mode and position output with bare \n plus relative cursor motion, so the injected carriage return snapped the cursor to column 0 and garbled their rendering under up/connect. (run is unaffected: it uses a Docker-attached PTY with no charmssh layer.)

Replace charmssh's default "session" channel handler with one that owns the raw gossh.Channel and runs the pty-req/env/window-change/shell/exec request loop itself, writing session output straight to the channel. charmssh still provides accept, handshake, public-key auth, idle timeout, and connection-level requests. AllocatePty() was not viable: it makes charmssh start its own channel<->pty bridge that steals session input (hung TestCleanExitViaSSH). Late or duplicate pty-req/env requests are rejected so the resize goroutine's channel can't be orphaned and the handler goroutine never races the request loop over sess.env.

Removing the rewrite also removed the \r\n that three other vibed-generated streams relied on, so each is restored explicitly:
- the reattach replay (scrollback + VTE render) is normalized to CRLF in Session.Attach (toCRLF), otherwise the reconstructed screen stair-steps after reattaching to a raw-mode TUI;
- PTY-session diagnostics written to Stderr are CRLF-cooked, mirroring charmssh's PTY-gated Stderr. Exec diagnostics stay raw, matching charmssh and the cooked non-PTY client;
- the session-selector BubbleTea program is cooked to CRLF (its output goes straight to the raw channel and, lacking TTY input, it emits bare \n for vertical motion), otherwise each redraw stair-steps on reattach. Live PTY bytes stay raw so a raw-mode TUI's bare \n reaches the client intact.