### PR TITLE
Show merged changelog spanning all skipped releases in `vibepit update`

### DIFF
--- a/.github/scripts/generate-release-metadata.py
+++ b/.github/scripts/generate-release-metadata.py
@@ -74,6 +74,31 @@ def parse_changelog(version: str, as_markdown: bool = False) -> str:
     return "\n".join(lines)
 
 
+def build_changes(version: str) -> dict:
+    changelog_file = Path(f"docs/changelogs/{version}.yml")
+    if not changelog_file.exists():
+        return {}
+
+    with open(changelog_file) as f:
+        data = yaml.safe_load(f)
+
+    changes = {}
+    for category in CHANGELOG_CATEGORIES:
+        entries = data.get(category, [])
+        if not entries:
+            continue
+        out = []
+        for entry in entries:
+            item = {"msg": entry["msg"]}
+            if pr := entry.get("pr"):
+                item["pr"] = str(pr)
+            if issue := entry.get("issue"):
+                item["issue"] = str(issue)
+            out.append(item)
+        changes[category] = out
+    return changes
+
+
 def parse_checksums(path: str) -> dict[str, str]:
     checksums = {}
     with open(path) as f:
@@ -100,12 +125,13 @@ def build_assets(version: str, bare_version: str, checksums: dict[str, str]) -> 
     return assets
 
 
-def write_version_metadata(bare_version: str, timestamp: str, changelog: str, assets: list[dict]):
+def write_version_metadata(bare_version: str, timestamp: str, changelog: str, changes: dict, assets: list[dict]):
     RELEASES_DIR.mkdir(parents=True, exist_ok=True)
     meta = {
         "version": bare_version,
         "timestamp": timestamp,
         "changelog": changelog,
+        "changes": changes,
         "assets": assets,
     }
     path = RELEASES_DIR / f"{bare_version}.json"
@@ -153,20 +179,44 @@ def generate_metadata_cmd():
     bare_version = version.lstrip("v")
 
     changelog = parse_changelog(bare_version)
+    changes = build_changes(bare_version)
     checksums = parse_checksums("/tmp/checksums.txt")
     assets = build_assets(version, bare_version, checksums)
 
-    write_version_metadata(bare_version, timestamp, changelog, assets)
+    write_version_metadata(bare_version, timestamp, changelog, changes, assets)
     update_channel_index(bare_version, timestamp)
+
+
+def backfill_changes_cmd():
+    for path in sorted(RELEASES_DIR.glob("*.json")):
+        if path.name in ("stable.json", "prerelease.json"):
+            continue
+        with open(path) as f:
+            meta = json.load(f)
+        version = meta.get("version")
+        if not version:
+            continue
+        # Assigning an existing key preserves its position, so re-running this
+        # on already-backfilled files is idempotent; a fresh file gets changes
+        # appended (field order is irrelevant to consumers).
+        meta["changes"] = build_changes(version)
+        with open(path, "w") as f:
+            json.dump(meta, f, indent=2)
+            f.write("\n")
+        print(f"backfilled {path.name}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--render-changelog", action="store_true",
                         help="Render changelog to stdout and exit")
+    parser.add_argument("--backfill-changes", action="store_true",
+                        help="Add the structured changes field to existing version JSONs and exit")
     args = parser.parse_args()
 
     if args.render_changelog:
         render_changelog_cmd()
+    elif args.backfill_changes:
+        backfill_changes_cmd()
     else:
         generate_metadata_cmd()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -146,8 +146,76 @@ func runCheck(client *selfupdate.Client, pre bool) error {
 	return nil
 }
 
+// updateChangelog returns the changelog text to display for an update, and
+// whether it merges multiple releases. It falls back to the target's rendered
+// changelog string (today's behavior) for a dev-build current version, a nil
+// idx (the direct --use path, or a cross-channel update whose enumeration
+// could not be completed), a single-release step, a fetch failure, or any
+// in-range release whose JSON predates the structured changes field. A release
+// that legitimately has no notes (an empty, non-nil changes map) is not a
+// fallback trigger: it contributes nothing to the merge but does not suppress
+// the other releases' notes.
+func updateChangelog(client *selfupdate.Client, idx *selfupdate.ChannelIndex, current string, meta *selfupdate.VersionMetadata) (string, bool) {
+	if idx == nil || selfupdate.IsDevBuild(current) {
+		return meta.Changelog, false
+	}
+
+	rng := idx.ReleasesBetween(current, meta.Version)
+	if len(rng) <= 1 {
+		return meta.Changelog, false
+	}
+
+	metas := make([]*selfupdate.VersionMetadata, 0, len(rng))
+	for _, r := range rng {
+		var vm *selfupdate.VersionMetadata
+		if r.Version == meta.Version {
+			vm = meta // target metadata already in hand; no refetch
+		} else {
+			fetched, err := client.FetchVersionMetadata(r.Version)
+			if err != nil {
+				return meta.Changelog, false
+			}
+			vm = fetched
+		}
+		// A nil map means the JSON predates the structured changes field, so it
+		// cannot be merged and we fall back. An empty (non-nil) map is a release
+		// with no notes; it stays in the merge contributing nothing.
+		if vm.Changes == nil {
+			return meta.Changelog, false
+		}
+		metas = append(metas, vm)
+	}
+
+	return selfupdate.RenderMerged(selfupdate.MergeChanges(metas)), true
+}
+
+// enumerationIndex returns the channel index used to enumerate the releases a
+// changelog should span, or nil when complete enumeration is not possible.
+// Stable and prerelease releases live in separate indexes, so a cross-channel
+// update must union both to avoid omitting the other channel's intervening
+// releases; a same-channel update wants only its resolved index (so a stable
+// update isn't polluted with prerelease notes). For a cross-channel update
+// whose other index cannot be fetched, enumeration would be incomplete:
+// returning the resolved index alone would render a partial merge under a
+// heading claiming the full range, so we return nil to signal the caller to
+// fall back to the target's changelog instead.
+func enumerationIndex(client *selfupdate.Client, idx *selfupdate.ChannelIndex, channel string, crossChannel bool) *selfupdate.ChannelIndex {
+	if !crossChannel {
+		return idx
+	}
+	other, found, err := client.FetchChannelIndex(selfupdate.OtherChannel(channel))
+	if err != nil || !found {
+		return nil
+	}
+	return &selfupdate.ChannelIndex{
+		Latest:   idx.Latest,
+		Releases: selfupdate.CombineReleases(idx, other),
+	}
+}
+
 func runBinaryUpdate(_ context.Context, client *selfupdate.Client, useVersion string, pre, yes bool) error {
 	var meta *selfupdate.VersionMetadata
+	var idx *selfupdate.ChannelIndex
 
 	if useVersion != "" {
 		// Direct version fetch, bypass channel logic.
@@ -158,10 +226,11 @@ func runBinaryUpdate(_ context.Context, client *selfupdate.Client, useVersion st
 		}
 	} else {
 		// Channel-based update check.
-		idx, channel, err := client.ResolveChannel(pre)
+		resolved, channel, err := client.ResolveChannel(pre)
 		if err != nil {
 			return err
 		}
+		idx = resolved
 
 		crossChannel := isCrossChannel(config.Version, channel)
 		if !selfupdate.ShouldUpdate(config.Version, idx.Latest, crossChannel) {
@@ -173,6 +242,10 @@ func runBinaryUpdate(_ context.Context, client *selfupdate.Client, useVersion st
 		if err != nil {
 			return err
 		}
+
+		// For a cross-channel update, widen enumeration to both channels so the
+		// merged changelog includes releases skipped on the other channel.
+		idx = enumerationIndex(client, idx, channel, crossChannel)
 	}
 
 	// Find asset for current platform.
@@ -185,8 +258,14 @@ func runBinaryUpdate(_ context.Context, client *selfupdate.Client, useVersion st
 	label := lipgloss.NewStyle().Foreground(tui.ColorCyan).Bold(true)
 	fmt.Printf("%s %s\n", label.Render("Current version:"), config.Version)
 	fmt.Printf("%s  %s (%s)\n", label.Render("Target version:"), meta.Version, meta.Timestamp)
-	if meta.Changelog != "" {
-		fmt.Printf("\n%s\n\n%s\n", label.Render("Changelog:"), meta.Changelog)
+
+	changelog, merged := updateChangelog(client, idx, config.Version, meta)
+	if changelog != "" {
+		heading := "Changelog:"
+		if merged {
+			heading = fmt.Sprintf("Changelog (v%s → v%s):", config.Version, meta.Version)
+		}
+		fmt.Printf("\n%s\n\n%s\n", label.Render(heading), changelog)
 	}
 
 	// Confirm.

--- a/cmd/update_changelog_test.go
+++ b/cmd/update_changelog_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bernd/vibepit/selfupdate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockServer returns a selfupdate.Client whose BaseURL points at an httptest
+// server serving each entry of data as {key}.json (404 otherwise). It serves
+// both version metadata and channel indexes, which share the {name}.json scheme.
+func newMockServer[T any](t *testing.T, data map[string]T) *selfupdate.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), ".json")
+		v, ok := data[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}))
+	t.Cleanup(srv.Close)
+	c := selfupdate.NewClient()
+	c.BaseURL = srv.URL
+	return c
+}
+
+func target040() *selfupdate.VersionMetadata {
+	return &selfupdate.VersionMetadata{
+		Version:   "0.4.0",
+		Changelog: "\nAdded:\n- v0.4.0 target rendered",
+		Changes: map[string][]selfupdate.ChangelogEntry{
+			"added": {{Msg: "New preset"}},
+		},
+	}
+}
+
+func TestUpdateChangelogSingleRelease(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	client := newMockServer[selfupdate.VersionMetadata](t, nil)
+	text, merged := updateChangelog(client, idx, "0.3.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, "\nAdded:\n- v0.4.0 target rendered", text)
+}
+
+func TestUpdateChangelogMerged(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newMockServer(t, map[string]selfupdate.VersionMetadata{
+		"0.3.0": {
+			Version:   "0.3.0",
+			Changelog: "ignored",
+			Changes: map[string][]selfupdate.ChangelogEntry{
+				"added": {{Msg: "extra-hosts option", PR: "11"}},
+			},
+		},
+	})
+	text, merged := updateChangelog(client, idx, "0.2.0", target040())
+	require.True(t, merged)
+	assert.Contains(t, text, "- v0.4.0: New preset")
+	assert.Contains(t, text, "- v0.3.0: extra-hosts option ([#11]")
+}
+
+func TestUpdateChangelogFetchErrorFallsBack(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newMockServer[selfupdate.VersionMetadata](t, nil) // 0.3.0 will 404
+	text, merged := updateChangelog(client, idx, "0.2.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}
+
+func TestUpdateChangelogDevBuildFallsBack(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newMockServer[selfupdate.VersionMetadata](t, nil)
+	text, merged := updateChangelog(client, idx, "0.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}
+
+// A target release with no notes (empty, non-nil changes map) must not suppress
+// the notes of intermediate releases that do have them.
+func TestUpdateChangelogEmptyTargetStillMergesIntermediate(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	emptyTarget := &selfupdate.VersionMetadata{
+		Version:   "0.4.0",
+		Changelog: "",
+		Changes:   map[string][]selfupdate.ChangelogEntry{}, // non-nil, no notes
+	}
+	client := newMockServer(t, map[string]selfupdate.VersionMetadata{
+		"0.3.0": {
+			Version: "0.3.0",
+			Changes: map[string][]selfupdate.ChangelogEntry{
+				"fixed": {{Msg: "Real intermediate fix", PR: "14"}},
+			},
+		},
+	})
+	text, merged := updateChangelog(client, idx, "0.2.0", emptyTarget)
+	require.True(t, merged)
+	assert.Contains(t, text, "- v0.3.0: Real intermediate fix ([#14]")
+}
+
+// A release whose JSON predates the structured changes field (nil map) cannot
+// be merged, so the whole update falls back to the rendered changelog.
+func TestUpdateChangelogNilIntermediateChangesFallsBack(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newMockServer(t, map[string]selfupdate.VersionMetadata{
+		"0.3.0": {
+			Version:   "0.3.0",
+			Changelog: "0.3.0 rendered",
+			Changes:   nil, // no structured field; encoded JSON omits "changes"
+		},
+	})
+	text, merged := updateChangelog(client, idx, "0.2.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}
+
+func TestEnumerationIndexSameChannelUnchanged(t *testing.T) {
+	stable := &selfupdate.ChannelIndex{Latest: "0.4.0", Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	client := newMockServer[selfupdate.ChannelIndex](t, nil)
+	got := enumerationIndex(client, stable, selfupdate.ChannelStable, false)
+	assert.Same(t, stable, got)
+}
+
+func TestEnumerationIndexCrossChannelCombines(t *testing.T) {
+	stable := &selfupdate.ChannelIndex{Latest: "0.4.0", Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	client := newMockServer(t, map[string]selfupdate.ChannelIndex{
+		selfupdate.ChannelPrerelease: {Latest: "0.5.0-rc.1", Releases: []selfupdate.ReleaseEntry{
+			{Version: "0.5.0-rc.1"}, {Version: "0.3.5-rc.1"},
+		}},
+	})
+	got := enumerationIndex(client, stable, selfupdate.ChannelStable, true)
+	assert.Equal(t, "0.4.0", got.Latest, "target version must be preserved")
+	versions := make([]string, len(got.Releases))
+	for i, r := range got.Releases {
+		versions[i] = r.Version
+	}
+	assert.ElementsMatch(t, []string{"0.4.0", "0.3.0", "0.5.0-rc.1", "0.3.5-rc.1"}, versions)
+}
+
+// When the other channel index can't be fetched, enumeration would be
+// incomplete, so the helper signals fallback by returning nil rather than the
+// partial resolved index.
+func TestEnumerationIndexCrossChannelOtherMissingSignalsIncomplete(t *testing.T) {
+	stable := &selfupdate.ChannelIndex{Latest: "0.4.0", Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	client := newMockServer[selfupdate.ChannelIndex](t, nil) // prerelease.json 404s
+	got := enumerationIndex(client, stable, selfupdate.ChannelStable, true)
+	assert.Nil(t, got)
+}
+
+// A nil enumeration index (incomplete cross-channel enumeration) must produce
+// the target changelog only — never a partial merge under a full-range heading.
+func TestUpdateChangelogNilIndexFallsBack(t *testing.T) {
+	client := newMockServer[selfupdate.VersionMetadata](t, nil)
+	text, merged := updateChangelog(client, nil, "0.2.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}

--- a/docs/content/releases/0.1.0.json
+++ b/docs/content/releases/0.1.0.json
@@ -2,6 +2,50 @@
   "version": "0.1.0",
   "timestamp": "2026-05-09T19:27:31+02:00",
   "changelog": "\nAdded:\n- SSH-based daemon mode with persistent PTY sessions (up, down, ssh, status commands)\n- Session selector TUI for detached sessions\n- Self-update command for binary updates with SHA256 and cosign verification\n- Session detector and live polling in monitor TUI\n- Global --version flag\n- Mistral AI network preset\n- NODE_USE_ENV_PROXY and grpc_proxy environment variables for sandbox\n\nChanged:\n- Update sandbox image to Ubuntu 26.04\n- Use \"unless-stopped\" restart policy for the proxy container\n- Add downloads.claude.ai:443 to Anthropic network preset\n- Add vuln.go.dev:443 to Golang network preset\n\nFixed:\n- Nil pointer dereference in control API log handler",
+  "changes": {
+    "added": [
+      {
+        "msg": "SSH-based daemon mode with persistent PTY sessions (up, down, ssh, status commands)"
+      },
+      {
+        "msg": "Session selector TUI for detached sessions"
+      },
+      {
+        "msg": "Self-update command for binary updates with SHA256 and cosign verification"
+      },
+      {
+        "msg": "Session detector and live polling in monitor TUI"
+      },
+      {
+        "msg": "Global --version flag"
+      },
+      {
+        "msg": "Mistral AI network preset"
+      },
+      {
+        "msg": "NODE_USE_ENV_PROXY and grpc_proxy environment variables for sandbox"
+      }
+    ],
+    "changed": [
+      {
+        "msg": "Update sandbox image to Ubuntu 26.04"
+      },
+      {
+        "msg": "Use \"unless-stopped\" restart policy for the proxy container"
+      },
+      {
+        "msg": "Add downloads.claude.ai:443 to Anthropic network preset"
+      },
+      {
+        "msg": "Add vuln.go.dev:443 to Golang network preset"
+      }
+    ],
+    "fixed": [
+      {
+        "msg": "Nil pointer dereference in control API log handler"
+      }
+    ]
+  },
   "assets": [
     {
       "os": "linux",

--- a/docs/content/releases/0.2.0.json
+++ b/docs/content/releases/0.2.0.json
@@ -2,6 +2,56 @@
   "version": "0.2.0",
   "timestamp": "2026-05-14T01:33:51+02:00",
   "changelog": "\nAdded:\n- Experimental terminal notification bar for interactive sessions\n- Non-interactive command execution via new `exec` command\n- Cosign signature verification for binary updates and container images\n- Playwright browser dependencies (Chromium, Firefox) in sandbox image ([#7](https://github.com/bernd/vibepit/pull/7))\n- xxd tool in sandbox image\n\nChanged:\n- Rename `ssh` command to `connect`\n- Reduce session startup verbosity\n- Improve `status` command output\n- Improve formatting of changelog in update command\n- Update dependencies\n\nFixed:\n- Permissions on cached vibepit binary on macOS\n- Image download progress output\n\nRemoved:\n- Remove obsolete `sessions` command (replaced by `status`)",
+  "changes": {
+    "added": [
+      {
+        "msg": "Experimental terminal notification bar for interactive sessions"
+      },
+      {
+        "msg": "Non-interactive command execution via new `exec` command"
+      },
+      {
+        "msg": "Cosign signature verification for binary updates and container images"
+      },
+      {
+        "msg": "Playwright browser dependencies (Chromium, Firefox) in sandbox image",
+        "pr": "7"
+      },
+      {
+        "msg": "xxd tool in sandbox image"
+      }
+    ],
+    "changed": [
+      {
+        "msg": "Rename `ssh` command to `connect`"
+      },
+      {
+        "msg": "Reduce session startup verbosity"
+      },
+      {
+        "msg": "Improve `status` command output"
+      },
+      {
+        "msg": "Improve formatting of changelog in update command"
+      },
+      {
+        "msg": "Update dependencies"
+      }
+    ],
+    "fixed": [
+      {
+        "msg": "Permissions on cached vibepit binary on macOS"
+      },
+      {
+        "msg": "Image download progress output"
+      }
+    ],
+    "removed": [
+      {
+        "msg": "Remove obsolete `sessions` command (replaced by `status`)"
+      }
+    ]
+  },
   "assets": [
     {
       "os": "linux",

--- a/docs/content/releases/0.3.0.json
+++ b/docs/content/releases/0.3.0.json
@@ -2,6 +2,54 @@
   "version": "0.3.0",
   "timestamp": "2026-06-09T00:04:34+02:00",
   "changelog": "\nAdded:\n- JetBrains AI service network preset\n- Packaging tools in the sandbox image\n- Session disconnect logging in `vibed`\n- `allow-cidr` config option to explicitly allow local IP ranges ([#10](https://github.com/bernd/vibepit/pull/10))\n- `extra-hosts` config option ([#11](https://github.com/bernd/vibepit/pull/11))\n- Global `upstream-dns` config option to set the upstream DNS server ([#12](https://github.com/bernd/vibepit/pull/12))\n- How-to for running with a local LLM provider ([#13](https://github.com/bernd/vibepit/pull/13))\n\nFixed:\n- Preserve formatting in `allow-http`/`allow-dns` appends ([#8](https://github.com/bernd/vibepit/pull/8))\n- State-file cleanup race in session test teardown ([#9](https://github.com/bernd/vibepit/pull/9))\n- `install -m` parameter in the Dockerfile\n- Force anonymous auth for cosign image signature verification\n- Distinguish forced detaches from clean shell exits",
+  "changes": {
+    "added": [
+      {
+        "msg": "JetBrains AI service network preset"
+      },
+      {
+        "msg": "Packaging tools in the sandbox image"
+      },
+      {
+        "msg": "Session disconnect logging in `vibed`"
+      },
+      {
+        "msg": "`allow-cidr` config option to explicitly allow local IP ranges",
+        "pr": "10"
+      },
+      {
+        "msg": "`extra-hosts` config option",
+        "pr": "11"
+      },
+      {
+        "msg": "Global `upstream-dns` config option to set the upstream DNS server",
+        "pr": "12"
+      },
+      {
+        "msg": "How-to for running with a local LLM provider",
+        "pr": "13"
+      }
+    ],
+    "fixed": [
+      {
+        "msg": "Preserve formatting in `allow-http`/`allow-dns` appends",
+        "pr": "8"
+      },
+      {
+        "msg": "State-file cleanup race in session test teardown",
+        "pr": "9"
+      },
+      {
+        "msg": "`install -m` parameter in the Dockerfile"
+      },
+      {
+        "msg": "Force anonymous auth for cosign image signature verification"
+      },
+      {
+        "msg": "Distinguish forced detaches from clean shell exits"
+      }
+    ]
+  },
   "assets": [
     {
       "os": "linux",

--- a/docs/superpowers/plans/2026-06-20-update-merged-changelog.md
+++ b/docs/superpowers/plans/2026-06-20-update-merged-changelog.md
@@ -1,0 +1,956 @@
+# Merged Changelog for Multi-Release `vibepit update` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the installed `vibepit` is several releases behind, `update` shows a single merged changelog covering every skipped release, with each entry prefixed by its source version.
+
+**Architecture:** Add a structured `changes` field to each per-version release JSON (alongside the existing rendered `changelog` string). The Go client enumerates the releases between the installed and target versions from the channel index, fetches each one's metadata, merges entries by category, and renders one version-prefixed block. Pure rendering/merge logic lives in the `selfupdate` package and is unit-tested; the `cmd/update.go` wiring fetches and displays.
+
+**Tech Stack:** Go (`golang.org/x/mod/semver`, `github.com/stretchr/testify`), Python 3 + PyYAML (release-metadata generator).
+
+## Global Constraints
+
+- Format code with `gofmt`; comments explain *why*, not *what*.
+- Tests are table-driven with subtests; assertions use `github.com/stretchr/testify` (`assert`/`require`).
+- Use `any`, not `interface{}`.
+- Category order is canonical everywhere: `added, changed, fixed, deprecated, removed, security`.
+- Repo URL in changelog links: `https://github.com/bernd/vibepit`.
+- The rendered `changelog` string field is **retained** in every JSON (feeds GitHub release notes and acts as the fallback).
+- `pr`/`issue` are emitted as **strings** in the structured `changes` field.
+- The Go renderer output must be byte-for-byte identical to the Python `parse_changelog` output (enforced by a consistency test).
+- Work happens on branch `update-merged-changelog`. Commit after every task.
+
+---
+
+### Task 1: Structured changelog types in `selfupdate`
+
+**Files:**
+- Modify: `selfupdate/releases.go` (add `ChangelogEntry`, `MergedEntry`, and the `Changes` field on `VersionMetadata`)
+- Test: `selfupdate/changelog_test.go` (create)
+
+**Interfaces:**
+- Produces:
+  - `type ChangelogEntry struct { Msg string; PR string; Issue string }` with JSON tags `msg`, `pr,omitempty`, `issue,omitempty`.
+  - `VersionMetadata.Changes map[string][]ChangelogEntry` with JSON tag `changes,omitempty`.
+  - `type MergedEntry struct { Entry ChangelogEntry; Version string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `selfupdate/changelog_test.go`:
+
+```go
+package selfupdate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionMetadataChangesParsing(t *testing.T) {
+	data := `{
+		"version": "0.3.0",
+		"timestamp": "2026-06-09T00:04:34+02:00",
+		"changelog": "\nAdded:\n- Thing",
+		"changes": {
+			"added": [{"msg": "Thing"}],
+			"fixed": [{"msg": "Bug", "pr": "8"}]
+		},
+		"assets": []
+	}`
+	var meta VersionMetadata
+	require.NoError(t, json.Unmarshal([]byte(data), &meta))
+
+	require.Len(t, meta.Changes["added"], 1)
+	assert.Equal(t, "Thing", meta.Changes["added"][0].Msg)
+	assert.Empty(t, meta.Changes["added"][0].PR)
+
+	require.Len(t, meta.Changes["fixed"], 1)
+	assert.Equal(t, "Bug", meta.Changes["fixed"][0].Msg)
+	assert.Equal(t, "8", meta.Changes["fixed"][0].PR)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./selfupdate/ -run TestVersionMetadataChangesParsing -v`
+Expected: FAIL — compile error, `meta.Changes` undefined / `VersionMetadata` has no field `Changes`.
+
+- [ ] **Step 3: Add the types**
+
+In `selfupdate/releases.go`, replace the `VersionMetadata` struct with:
+
+```go
+// VersionMetadata represents a per-version metadata file (e.g., 0.2.0.json).
+type VersionMetadata struct {
+	Version   string                      `json:"version"`
+	Timestamp string                      `json:"timestamp"`
+	Changelog string                      `json:"changelog"`
+	Changes   map[string][]ChangelogEntry `json:"changes,omitempty"`
+	Assets    []Asset                     `json:"assets"`
+}
+
+// ChangelogEntry is a single structured changelog entry parsed from a
+// docs/changelogs/{version}.yml file.
+type ChangelogEntry struct {
+	Msg   string `json:"msg"`
+	PR    string `json:"pr,omitempty"`
+	Issue string `json:"issue,omitempty"`
+}
+
+// MergedEntry is a ChangelogEntry tagged with the release version it came
+// from, used when merging changelogs across multiple releases.
+type MergedEntry struct {
+	Entry   ChangelogEntry
+	Version string
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./selfupdate/ -run TestVersionMetadataChangesParsing -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add selfupdate/releases.go selfupdate/changelog_test.go
+git commit -m "Add structured changelog types to selfupdate"
+```
+
+---
+
+### Task 2: `ReleasesBetween` on `ChannelIndex`
+
+**Files:**
+- Modify: `selfupdate/releases.go` (add method; add `sort` import)
+- Test: `selfupdate/releases_test.go` (append test)
+
+**Interfaces:**
+- Consumes: `ChannelIndex`, `ReleaseEntry` (existing), `addV` (from `version.go`).
+- Produces: `func (idx *ChannelIndex) ReleasesBetween(current, target string) []ReleaseEntry` — entries with `current < v <= target` by semver, sorted newest-first. Callers must guard dev-build `current` themselves (an invalid semver `current` sorts below everything and would match all releases).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `selfupdate/releases_test.go`:
+
+```go
+func TestReleasesBetween(t *testing.T) {
+	idx := &ChannelIndex{
+		Releases: []ReleaseEntry{
+			{Version: "0.4.0"}, {Version: "0.3.0"},
+			{Version: "0.2.0"}, {Version: "0.1.0"},
+		},
+	}
+	tests := []struct {
+		name           string
+		current, target string
+		want           []string
+	}{
+		{"spans multiple", "0.1.0", "0.4.0", []string{"0.4.0", "0.3.0", "0.2.0"}},
+		{"single step", "0.3.0", "0.4.0", []string{"0.4.0"}},
+		{"current equals target", "0.4.0", "0.4.0", nil},
+		{"current above latest", "0.5.0", "0.4.0", nil},
+		{"target excludes newer", "0.1.0", "0.3.0", []string{"0.3.0", "0.2.0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := idx.ReleasesBetween(tt.current, tt.target)
+			var versions []string
+			for _, r := range got {
+				versions = append(versions, r.Version)
+			}
+			assert.Equal(t, tt.want, versions)
+		})
+	}
+}
+
+func TestReleasesBetweenSortsNewestFirst(t *testing.T) {
+	idx := &ChannelIndex{
+		Releases: []ReleaseEntry{
+			{Version: "0.2.0"}, {Version: "0.4.0"}, {Version: "0.3.0"},
+		},
+	}
+	got := idx.ReleasesBetween("0.1.0", "0.4.0")
+	require.Len(t, got, 3)
+	assert.Equal(t, "0.4.0", got[0].Version)
+	assert.Equal(t, "0.3.0", got[1].Version)
+	assert.Equal(t, "0.2.0", got[2].Version)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./selfupdate/ -run TestReleasesBetween -v`
+Expected: FAIL — `idx.ReleasesBetween` undefined.
+
+- [ ] **Step 3: Implement the method**
+
+Add `"sort"` to the imports in `selfupdate/releases.go`, then add:
+
+```go
+// ReleasesBetween returns the releases newer than current and no newer than
+// target (current < v <= target), sorted newest-first. The caller must ensure
+// current is a valid release version; an invalid semver sorts below all
+// releases and would match everything.
+func (idx *ChannelIndex) ReleasesBetween(current, target string) []ReleaseEntry {
+	var out []ReleaseEntry
+	for _, r := range idx.Releases {
+		if semver.Compare(addV(current), addV(r.Version)) < 0 &&
+			semver.Compare(addV(r.Version), addV(target)) <= 0 {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return semver.Compare(addV(out[i].Version), addV(out[j].Version)) > 0
+	})
+	return out
+}
+```
+
+Add `"golang.org/x/mod/semver"` to the imports if not already present (it is used by `version.go` in the same package, but `releases.go` needs its own import).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./selfupdate/ -run TestReleasesBetween -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add selfupdate/releases.go selfupdate/releases_test.go
+git commit -m "Add ChannelIndex.ReleasesBetween for changelog range enumeration"
+```
+
+---
+
+### Task 3: Single-version renderer (`RenderChanges`)
+
+**Files:**
+- Create: `selfupdate/changelog.go`
+- Test: `selfupdate/changelog_test.go` (append)
+
+**Interfaces:**
+- Produces:
+  - `func RenderChanges(changes map[string][]ChangelogEntry) string` — no version prefix.
+  - Unexported helpers `formatEntry`, `refSuffix`, `capitalizeCategory`, and `changelogCategories` / `repoURL` constants (reused by Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `selfupdate/changelog_test.go`:
+
+```go
+func TestRenderChanges(t *testing.T) {
+	changes := map[string][]ChangelogEntry{
+		"added": {
+			{Msg: "Plain feature"},
+			{Msg: "Feature with PR", PR: "11"},
+		},
+		"fixed": {
+			{Msg: "Bug with issue", Issue: "5"},
+			{Msg: "Bug with both", PR: "8", Issue: "9"},
+		},
+	}
+	want := "\nAdded:\n" +
+		"- Plain feature\n" +
+		"- Feature with PR ([#11](https://github.com/bernd/vibepit/pull/11))\n" +
+		"\nFixed:\n" +
+		"- Bug with issue ([#5](https://github.com/bernd/vibepit/issues/5))\n" +
+		"- Bug with both ([#8](https://github.com/bernd/vibepit/pull/8), [#9](https://github.com/bernd/vibepit/issues/9))"
+	assert.Equal(t, want, RenderChanges(changes))
+}
+
+func TestRenderChangesEmpty(t *testing.T) {
+	assert.Equal(t, "", RenderChanges(map[string][]ChangelogEntry{}))
+	assert.Equal(t, "", RenderChanges(nil))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./selfupdate/ -run TestRenderChanges -v`
+Expected: FAIL — `RenderChanges` undefined.
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `selfupdate/changelog.go`:
+
+```go
+package selfupdate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// repoURL is the GitHub repository used to build changelog PR/issue links.
+// Must match REPO_URL in .github/scripts/generate-release-metadata.py.
+const repoURL = "https://github.com/bernd/vibepit"
+
+// changelogCategories is the canonical render order for changelog sections.
+// Must match CHANGELOG_CATEGORIES in the metadata generator.
+var changelogCategories = []string{"added", "changed", "fixed", "deprecated", "removed", "security"}
+
+// refSuffix renders the trailing " ([#pr](...), [#issue](...))" for an entry,
+// or "" when it has no references.
+func refSuffix(e ChangelogEntry) string {
+	var refs []string
+	if e.PR != "" {
+		refs = append(refs, fmt.Sprintf("[#%s](%s/pull/%s)", e.PR, repoURL, e.PR))
+	}
+	if e.Issue != "" {
+		refs = append(refs, fmt.Sprintf("[#%s](%s/issues/%s)", e.Issue, repoURL, e.Issue))
+	}
+	if len(refs) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(refs, ", ") + ")"
+}
+
+// formatEntry renders a single entry line without a version prefix.
+func formatEntry(e ChangelogEntry) string {
+	return "- " + e.Msg + refSuffix(e)
+}
+
+// capitalizeCategory upper-cases the first letter of a category name to match
+// Python's str.capitalize() for these single lowercase words.
+func capitalizeCategory(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// RenderChanges renders a single version's structured changes to the same text
+// the Python generator produces for the rendered "changelog" field. No version
+// prefix is added.
+func RenderChanges(changes map[string][]ChangelogEntry) string {
+	var lines []string
+	for _, cat := range changelogCategories {
+		entries := changes[cat]
+		if len(entries) == 0 {
+			continue
+		}
+		lines = append(lines, "\n"+capitalizeCategory(cat)+":")
+		for _, e := range entries {
+			lines = append(lines, formatEntry(e))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./selfupdate/ -run TestRenderChanges -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add selfupdate/changelog.go selfupdate/changelog_test.go
+git commit -m "Add RenderChanges single-version changelog renderer"
+```
+
+---
+
+### Task 4: Merge + version-prefixed renderer (`MergeChanges`, `RenderMerged`)
+
+**Files:**
+- Modify: `selfupdate/changelog.go`
+- Test: `selfupdate/changelog_test.go` (append)
+
+**Interfaces:**
+- Consumes: `VersionMetadata`, `MergedEntry`, `ChangelogEntry`, `refSuffix`, `capitalizeCategory`, `changelogCategories`.
+- Produces:
+  - `func MergeChanges(metas []*VersionMetadata) map[string][]MergedEntry` — `metas` passed newest→oldest; concatenates per category, tagging each entry with its `Version`.
+  - `func RenderMerged(merged map[string][]MergedEntry) string` — same layout as `RenderChanges`, each line prefixed `- v{version}: `.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `selfupdate/changelog_test.go`:
+
+```go
+func TestMergeChangesAndRenderMerged(t *testing.T) {
+	newer := &VersionMetadata{
+		Version: "0.4.0",
+		Changes: map[string][]ChangelogEntry{
+			"fixed": {{Msg: "Resolve issue from 0.3.0", PR: "21"}},
+			"added": {{Msg: "New preset"}},
+		},
+	}
+	older := &VersionMetadata{
+		Version: "0.3.0",
+		Changes: map[string][]ChangelogEntry{
+			"fixed": {{Msg: "Partial fix", PR: "14"}},
+			"added": {{Msg: "extra-hosts option", PR: "11"}},
+		},
+	}
+
+	// Passed newest-first.
+	merged := MergeChanges([]*VersionMetadata{newer, older})
+
+	require.Len(t, merged["fixed"], 2)
+	assert.Equal(t, "0.4.0", merged["fixed"][0].Version)
+	assert.Equal(t, "0.3.0", merged["fixed"][1].Version)
+
+	want := "\nAdded:\n" +
+		"- v0.4.0: New preset\n" +
+		"- v0.3.0: extra-hosts option ([#11](https://github.com/bernd/vibepit/pull/11))\n" +
+		"\nFixed:\n" +
+		"- v0.4.0: Resolve issue from 0.3.0 ([#21](https://github.com/bernd/vibepit/pull/21))\n" +
+		"- v0.3.0: Partial fix ([#14](https://github.com/bernd/vibepit/pull/14))"
+	assert.Equal(t, want, RenderMerged(merged))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./selfupdate/ -run TestMergeChangesAndRenderMerged -v`
+Expected: FAIL — `MergeChanges` / `RenderMerged` undefined.
+
+- [ ] **Step 3: Implement merge + merged renderer**
+
+Append to `selfupdate/changelog.go`:
+
+```go
+// MergeChanges concatenates the structured changes of multiple releases by
+// category, tagging each entry with its source version. metas must be ordered
+// newest-first so that the newest release's entries lead each category.
+func MergeChanges(metas []*VersionMetadata) map[string][]MergedEntry {
+	merged := make(map[string][]MergedEntry)
+	for _, m := range metas {
+		for cat, entries := range m.Changes {
+			for _, e := range entries {
+				merged[cat] = append(merged[cat], MergedEntry{Entry: e, Version: m.Version})
+			}
+		}
+	}
+	return merged
+}
+
+// RenderMerged renders merged changes as a single block, prefixing every entry
+// with its source version (e.g. "- v0.4.0: ...").
+func RenderMerged(merged map[string][]MergedEntry) string {
+	var lines []string
+	for _, cat := range changelogCategories {
+		entries := merged[cat]
+		if len(entries) == 0 {
+			continue
+		}
+		lines = append(lines, "\n"+capitalizeCategory(cat)+":")
+		for _, m := range entries {
+			lines = append(lines, "- v"+m.Version+": "+m.Entry.Msg+refSuffix(m.Entry))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./selfupdate/ -run TestMergeChangesAndRenderMerged -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add selfupdate/changelog.go selfupdate/changelog_test.go
+git commit -m "Add MergeChanges and RenderMerged version-prefixed renderer"
+```
+
+---
+
+### Task 5: Generator emits `changes` + backfill existing JSONs
+
+**Files:**
+- Modify: `.github/scripts/generate-release-metadata.py`
+- Modify (regenerated output): `docs/content/releases/0.1.0.json`, `0.2.0.json`, `0.3.0.json`
+
+**Interfaces:**
+- Produces: every per-version JSON gains a `changes` object (between `changelog` and `assets`), built from the same YAML source. `pr`/`issue` coerced to strings.
+
+- [ ] **Step 1: Add `build_changes` and wire it into metadata generation**
+
+In `.github/scripts/generate-release-metadata.py`, add this function after `parse_changelog` (after line 74):
+
+```python
+def build_changes(version: str) -> dict:
+    changelog_file = Path(f"docs/changelogs/{version}.yml")
+    if not changelog_file.exists():
+        return {}
+
+    with open(changelog_file) as f:
+        data = yaml.safe_load(f)
+
+    changes = {}
+    for category in CHANGELOG_CATEGORIES:
+        entries = data.get(category, [])
+        if not entries:
+            continue
+        out = []
+        for entry in entries:
+            item = {"msg": entry["msg"]}
+            if (pr := entry.get("pr")) is not None:
+                item["pr"] = str(pr)
+            if (issue := entry.get("issue")) is not None:
+                item["issue"] = str(issue)
+            out.append(item)
+        changes[category] = out
+    return changes
+```
+
+Change `write_version_metadata` (currently lines 103-114) to accept and write `changes`:
+
+```python
+def write_version_metadata(bare_version: str, timestamp: str, changelog: str, changes: dict, assets: list[dict]):
+    RELEASES_DIR.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "version": bare_version,
+        "timestamp": timestamp,
+        "changelog": changelog,
+        "changes": changes,
+        "assets": assets,
+    }
+    path = RELEASES_DIR / f"{bare_version}.json"
+    with open(path, "w") as f:
+        json.dump(meta, f, indent=2)
+        f.write("\n")
+```
+
+In `generate_metadata_cmd` (currently lines 146-160), build and pass `changes`:
+
+```python
+def generate_metadata_cmd():
+    version = os.environ.get("VERSION")
+    timestamp = os.environ.get("TIMESTAMP")
+
+    if not version or not timestamp:
+        sys.exit("VERSION and TIMESTAMP environment variables are required")
+
+    bare_version = version.lstrip("v")
+
+    changelog = parse_changelog(bare_version)
+    changes = build_changes(bare_version)
+    checksums = parse_checksums("/tmp/checksums.txt")
+    assets = build_assets(version, bare_version, checksums)
+
+    write_version_metadata(bare_version, timestamp, changelog, changes, assets)
+    update_channel_index(bare_version, timestamp)
+```
+
+- [ ] **Step 2: Add a `--backfill-changes` mode**
+
+Add this function after `generate_metadata_cmd`:
+
+```python
+def backfill_changes_cmd():
+    for path in sorted(RELEASES_DIR.glob("*.json")):
+        if path.name in ("stable.json", "prerelease.json"):
+            continue
+        with open(path) as f:
+            meta = json.load(f)
+        version = meta.get("version")
+        if not version:
+            continue
+        changes = build_changes(version)
+        new_meta = {}
+        for key, value in meta.items():
+            if key == "changes":
+                continue
+            new_meta[key] = value
+            if key == "changelog":
+                new_meta["changes"] = changes
+        if "changes" not in new_meta:
+            new_meta["changes"] = changes
+        with open(path, "w") as f:
+            json.dump(new_meta, f, indent=2)
+            f.write("\n")
+        print(f"backfilled {path.name}")
+```
+
+Wire it into `__main__` (currently lines 163-172):
+
+```python
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--render-changelog", action="store_true",
+                        help="Render changelog to stdout and exit")
+    parser.add_argument("--backfill-changes", action="store_true",
+                        help="Add the structured changes field to existing version JSONs and exit")
+    args = parser.parse_args()
+
+    if args.render_changelog:
+        render_changelog_cmd()
+    elif args.backfill_changes:
+        backfill_changes_cmd()
+    else:
+        generate_metadata_cmd()
+```
+
+- [ ] **Step 3: Run the backfill to regenerate committed JSONs**
+
+Run from the repo root:
+
+```bash
+python3 .github/scripts/generate-release-metadata.py --backfill-changes
+```
+
+Expected output (order may vary):
+```
+backfilled 0.1.0.json
+backfilled 0.2.0.json
+backfilled 0.3.0.json
+```
+
+- [ ] **Step 4: Verify the diff only adds `changes`**
+
+Run: `git diff --stat docs/content/releases/`
+Expected: only `0.1.0.json`, `0.2.0.json`, `0.3.0.json` changed.
+
+Run: `git diff docs/content/releases/0.3.0.json`
+Expected: a new `"changes": { ... }` block inserted after the `"changelog"` line; `version`, `timestamp`, `changelog`, and `assets` unchanged. Spot-check that `added`/`fixed` entries with PR numbers show `"pr": "10"` etc. as strings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/scripts/generate-release-metadata.py docs/content/releases/0.1.0.json docs/content/releases/0.2.0.json docs/content/releases/0.3.0.json
+git commit -m "Emit structured changes field and backfill release JSONs"
+```
+
+---
+
+### Task 6: Go ↔ Python consistency test
+
+**Files:**
+- Test: `selfupdate/changelog_test.go` (append)
+
+**Interfaces:**
+- Consumes: `RenderChanges`, `VersionMetadata`, the committed `docs/content/releases/*.json` (now containing `changes` after Task 5).
+
+- [ ] **Step 1: Write the test**
+
+Append to `selfupdate/changelog_test.go` (and ensure imports include `os` and `path/filepath`):
+
+```go
+func TestRenderChangesMatchesReleaseJSON(t *testing.T) {
+	paths, err := filepath.Glob("../docs/content/releases/*.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+
+	checked := 0
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if base == "stable.json" || base == "prerelease.json" {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		require.NoError(t, err, p)
+
+		var meta VersionMetadata
+		require.NoError(t, json.Unmarshal(data, &meta), p)
+
+		if len(meta.Changes) == 0 {
+			continue
+		}
+		assert.Equal(t, meta.Changelog, RenderChanges(meta.Changes),
+			"RenderChanges output drifted from the rendered changelog in %s", base)
+		checked++
+	}
+	assert.Positive(t, checked, "expected at least one release JSON with a changes field")
+}
+```
+
+The `changelog_test.go` import block must be:
+
+```go
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./selfupdate/ -run TestRenderChangesMatchesReleaseJSON -v`
+Expected: PASS, having checked the 3 backfilled release JSONs. If it FAILS, the Go renderer and Python generator disagree — diff the expected vs actual to find the formatting mismatch and fix `selfupdate/changelog.go` (do not edit the JSON to match a wrong renderer).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add selfupdate/changelog_test.go
+git commit -m "Pin Go changelog renderer to generator output via consistency test"
+```
+
+---
+
+### Task 7: Wire merged changelog into `cmd/update.go`
+
+**Files:**
+- Modify: `cmd/update.go` (`runBinaryUpdate`, lines 149-190; add `updateChangelog` helper)
+- Test: `cmd/update_changelog_test.go` (create)
+
+**Interfaces:**
+- Consumes: `selfupdate.Client`, `selfupdate.ChannelIndex`, `selfupdate.VersionMetadata`, `selfupdate.IsDevBuild`, `selfupdate.MergeChanges`, `selfupdate.RenderMerged`, `config.Version`.
+- Produces: `func updateChangelog(client *selfupdate.Client, idx *selfupdate.ChannelIndex, current string, meta *selfupdate.VersionMetadata) (text string, merged bool)`.
+  - `idx == nil` (direct `--use` path) or `IsDevBuild(current)` → `(meta.Changelog, false)`.
+  - `len(ReleasesBetween) <= 1` → `(meta.Changelog, false)`.
+  - Otherwise fetch each in-range version (reusing `meta` for the target). On any fetch error, or any in-range version missing structured `Changes` → `(meta.Changelog, false)`. On success → `(RenderMerged(MergeChanges(metas)), true)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/update_changelog_test.go`:
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bernd/vibepit/selfupdate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient returns a selfupdate.Client whose BaseURL points at an
+// httptest server serving the given versions as {version}.json (404 otherwise).
+func newTestClient(t *testing.T, versions map[string]selfupdate.VersionMetadata) *selfupdate.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ver := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), ".json")
+		meta, ok := versions[ver]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(meta)
+	}))
+	t.Cleanup(srv.Close)
+	c := selfupdate.NewClient()
+	c.BaseURL = srv.URL
+	return c
+}
+
+func target040() *selfupdate.VersionMetadata {
+	return &selfupdate.VersionMetadata{
+		Version:   "0.4.0",
+		Changelog: "\nAdded:\n- v0.4.0 target rendered",
+		Changes: map[string][]selfupdate.ChangelogEntry{
+			"added": {{Msg: "New preset"}},
+		},
+	}
+}
+
+func TestUpdateChangelogSingleRelease(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	client := newTestClient(t, nil)
+	text, merged := updateChangelog(client, idx, "0.3.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, "\nAdded:\n- v0.4.0 target rendered", text)
+}
+
+func TestUpdateChangelogMerged(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newTestClient(t, map[string]selfupdate.VersionMetadata{
+		"0.3.0": {
+			Version:   "0.3.0",
+			Changelog: "ignored",
+			Changes: map[string][]selfupdate.ChangelogEntry{
+				"added": {{Msg: "extra-hosts option", PR: "11"}},
+			},
+		},
+	})
+	text, merged := updateChangelog(client, idx, "0.2.0", target040())
+	require.True(t, merged)
+	assert.Contains(t, text, "- v0.4.0: New preset")
+	assert.Contains(t, text, "- v0.3.0: extra-hosts option ([#11]")
+}
+
+func TestUpdateChangelogFetchErrorFallsBack(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newTestClient(t, nil) // 0.3.0 will 404
+	text, merged := updateChangelog(client, idx, "0.2.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}
+
+func TestUpdateChangelogDevBuildFallsBack(t *testing.T) {
+	idx := &selfupdate.ChannelIndex{Releases: []selfupdate.ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"}, {Version: "0.2.0"},
+	}}
+	client := newTestClient(t, nil)
+	text, merged := updateChangelog(client, idx, "0.0", target040())
+	assert.False(t, merged)
+	assert.Equal(t, target040().Changelog, text)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/ -run TestUpdateChangelog -v`
+Expected: FAIL — `updateChangelog` undefined.
+
+- [ ] **Step 3: Implement `updateChangelog` and rewire `runBinaryUpdate`**
+
+Add the helper to `cmd/update.go`:
+
+```go
+// updateChangelog returns the changelog text to display for an update, and
+// whether it merges multiple releases. For a dev-build current version, the
+// direct --use path (idx == nil), a single-release step, a fetch failure, or
+// any in-range release lacking structured changes, it falls back to the
+// target's rendered changelog string (today's behavior).
+func updateChangelog(client *selfupdate.Client, idx *selfupdate.ChannelIndex, current string, meta *selfupdate.VersionMetadata) (string, bool) {
+	if idx == nil || selfupdate.IsDevBuild(current) {
+		return meta.Changelog, false
+	}
+
+	rng := idx.ReleasesBetween(current, meta.Version)
+	if len(rng) <= 1 {
+		return meta.Changelog, false
+	}
+
+	metas := make([]*selfupdate.VersionMetadata, 0, len(rng))
+	for _, r := range rng {
+		vm := meta
+		if r.Version != meta.Version {
+			fetched, err := client.FetchVersionMetadata(r.Version)
+			if err != nil {
+				return meta.Changelog, false
+			}
+			vm = fetched
+		}
+		if len(vm.Changes) == 0 {
+			return meta.Changelog, false
+		}
+		metas = append(metas, vm)
+	}
+
+	return selfupdate.RenderMerged(selfupdate.MergeChanges(metas)), true
+}
+```
+
+In `runBinaryUpdate`, hoist `idx` to function scope so it is available at display time. Replace the block at lines 150-176 with:
+
+```go
+	var meta *selfupdate.VersionMetadata
+	var idx *selfupdate.ChannelIndex
+
+	if useVersion != "" {
+		// Direct version fetch, bypass channel logic.
+		var err error
+		meta, err = client.FetchVersionMetadata(useVersion)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Channel-based update check.
+		resolved, channel, err := client.ResolveChannel(pre)
+		if err != nil {
+			return err
+		}
+		idx = resolved
+
+		crossChannel := isCrossChannel(config.Version, channel)
+		if !selfupdate.ShouldUpdate(config.Version, idx.Latest, crossChannel) {
+			fmt.Println("Binary is up to date.")
+			return nil
+		}
+
+		meta, err = client.FetchVersionMetadata(idx.Latest)
+		if err != nil {
+			return err
+		}
+	}
+```
+
+Replace the display block at lines 184-190 with:
+
+```go
+	// Display update info.
+	label := lipgloss.NewStyle().Foreground(tui.ColorCyan).Bold(true)
+	fmt.Printf("%s %s\n", label.Render("Current version:"), config.Version)
+	fmt.Printf("%s  %s (%s)\n", label.Render("Target version:"), meta.Version, meta.Timestamp)
+
+	changelog, merged := updateChangelog(client, idx, config.Version, meta)
+	if changelog != "" {
+		heading := "Changelog:"
+		if merged {
+			heading = fmt.Sprintf("Changelog (v%s → v%s):", config.Version, meta.Version)
+		}
+		fmt.Printf("\n%s\n\n%s\n", label.Render(heading), changelog)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/ -run TestUpdateChangelog -v`
+Expected: PASS (all four cases).
+
+Run: `go build ./...`
+Expected: builds cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/update.go cmd/update_changelog_test.go
+git commit -m "Show merged changelog when update spans multiple releases"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run the package tests**
+
+Run: `make test`
+Expected: PASS, including `selfupdate` and `cmd` packages.
+
+- [ ] **Step 2: Confirm gofmt cleanliness**
+
+Run: `gofmt -l selfupdate/ cmd/`
+Expected: no output (no files need formatting).
+
+- [ ] **Step 3: Final commit (only if Step 2 reformatted anything)**
+
+```bash
+git add -u && git commit -m "gofmt"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Structured `changes` field + retained rendered `changelog` → Tasks 1, 5. ✓
+- `pr`/`issue` as strings → Task 5 `build_changes`. ✓
+- Backfill of historical JSONs → Task 5. ✓
+- `ReleasesBetween` newest-first semver filter → Task 2. ✓
+- `MergeChanges` newest-first + version tagging → Task 4. ✓
+- `RenderChanges` (no prefix) + `RenderMerged` (`- vX.Y.Z:` prefix) → Tasks 3, 4. ✓
+- Consistency test `RenderChanges == changelog` → Task 6. ✓
+- Channel-path wiring, single vs merged, `Changelog (v.. → v..)` label → Task 7. ✓
+- Fallbacks: dev build, `--use` path, single step, fetch error, missing structured data → Task 7 `updateChangelog` + its tests. ✓
+- Direct `--use` path unchanged behavior → Task 7 (`idx == nil`). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full, final code (no scratch shims to clean up).
+
+**Type consistency:** `ChangelogEntry{Msg,PR,Issue}`, `MergedEntry{Entry,Version}`, `VersionMetadata.Changes`, `ReleasesBetween`, `MergeChanges`, `RenderChanges`, `RenderMerged`, and `updateChangelog(client, idx, current, meta) (string, bool)` are used consistently across tasks. Python `build_changes`/`write_version_metadata(..., changes, assets)` signatures match their call sites.

--- a/docs/superpowers/specs/2026-06-20-update-merged-changelog-design.md
+++ b/docs/superpowers/specs/2026-06-20-update-merged-changelog-design.md
@@ -1,0 +1,208 @@
+# Design: Merged changelog for multi-release `vibepit update`
+
+Date: 2026-06-20
+
+## Problem
+
+`vibepit update` shows the changelog for only the *target* release. When the
+installed binary is more than one release behind, the changelogs for the
+skipped intermediate releases are never shown. A user on 0.1.0 updating to
+0.3.0 sees 0.3.0's notes but never 0.2.0's.
+
+In the channel-based update path (`cmd/update.go`, `runBinaryUpdate`), the code
+resolves the channel index — which lists *every* release — but then fetches and
+prints metadata for only `idx.Latest`. The rendered changelog text exists only
+in each per-version JSON (`docs/content/releases/{version}.json`), not in the
+channel index.
+
+## Goal
+
+When the installed version is several releases behind, show a single **merged**
+changelog covering every skipped release (every release strictly newer than the
+installed version, up to and including the target), grouped by category. Each
+entry is prefixed with the version it came from so cross-release context is
+clear (e.g. a 0.4.0 fix for an issue introduced in 0.3.0).
+
+Non-goals: changing the release pipeline beyond adding structured changelog
+data; changing the `--version` direct-install path; redesigning terminal
+changelog styling.
+
+## Approach
+
+Client-side enumeration and merge. The channel index already lists all
+releases with versions and timestamps, so the client can compute exactly which
+releases sit between the installed and target versions, fetch each one's
+metadata, and merge their changelog entries.
+
+To merge client-side we add a **structured** changelog field to each
+per-version JSON (in addition to the existing rendered `changelog` string).
+The Go client renders the merged result, including PR/issue links.
+
+Alternatives considered and rejected:
+
+- **Per-version rendered blocks** (stacked, no merge): simpler, but the user
+  wants a single merged changelog.
+- **Server-side aggregated changelog endpoint**: one fetch, but changes the
+  data format/CI for the sake of 1–3 tiny fetches. YAGNI.
+- **Embed changelogs into the channel index**: zero extra fetches, but bloats
+  the index with full changelog history and duplicates data.
+
+## Data format
+
+Each `docs/content/releases/{version}.json` gains a `changes` field alongside
+the existing rendered `changelog` string. The rendered string is retained: it
+still feeds GitHub release notes (`--render-changelog`) and acts as a fallback.
+
+```json
+{
+  "version": "0.3.0",
+  "timestamp": "…",
+  "changelog": "\nAdded:\n- …",
+  "changes": {
+    "added": [
+      {"msg": "JetBrains AI preset"},
+      {"msg": "extra-hosts option", "pr": "11"}
+    ],
+    "fixed": [
+      {"msg": "Race in DNS server", "pr": "8"}
+    ]
+  },
+  "assets": [ … ]
+}
+```
+
+- Keys are the canonical categories, only present when non-empty:
+  `added, changed, fixed, deprecated, removed, security`.
+- Each entry has `msg`, and optional `pr` / `issue`, both emitted as **strings**
+  (coerced from the YAML, which may use integers) so Go unmarshalling is
+  trivial.
+
+## Generator changes (`.github/scripts/generate-release-metadata.py`)
+
+- Add `build_changes(version) -> dict` that reads the same
+  `docs/changelogs/{version}.yml`, iterates `CHANGELOG_CATEGORIES`, and emits
+  `{category: [{"msg": …, "pr": str(pr)?, "issue": str(issue)?}, …]}` for
+  non-empty categories. `pr`/`issue` coerced to strings.
+- `write_version_metadata` includes `"changes"` in the written JSON.
+- The existing `parse_changelog` / rendered `changelog` string is unchanged.
+
+### Backfill
+
+Existing committed JSONs (`0.1.0.json`, `0.2.0.json`, `0.3.0.json`) predate the
+`changes` field. Add a `--backfill-changes` mode to the script that, for every
+existing `docs/content/releases/{version}.json`, injects `changes` from its YAML
+source while leaving `timestamp`, `changelog`, and `assets` untouched. Run once
+to update the committed historical files. Future releases get `changes`
+automatically via the modified generator.
+
+A version JSON whose YAML source is missing is left without `changes` (the
+client falls back to its rendered string).
+
+## Go changes (`selfupdate` package — pure, unit-tested)
+
+### Types
+
+```go
+type ChangelogEntry struct {
+    Msg   string `json:"msg"`
+    PR    string `json:"pr,omitempty"`
+    Issue string `json:"issue,omitempty"`
+}
+
+// VersionMetadata gains:
+//   Changes map[string][]ChangelogEntry `json:"changes,omitempty"`
+
+type MergedEntry struct {
+    Entry   ChangelogEntry
+    Version string
+}
+```
+
+### Functions
+
+- `func (idx *ChannelIndex) ReleasesBetween(current, target string) []ReleaseEntry`
+  — returns the entries from `idx.Releases` where `current < v <= target` by
+  `semver.Compare`, ordered **newest-first**.
+
+- `func MergeChanges(metas []*VersionMetadata) map[string][]MergedEntry`
+  — `metas` passed newest→oldest; concatenates entries per category, tagging
+  each with its source version. Within a category, newest version's entries
+  come first (driven by input order).
+
+- `func RenderChanges(changes map[string][]ChangelogEntry) string`
+  — renders a **single** version's changes with **no** version prefix. Byte-for-
+  byte reproduction of the Python output: leading `\n`; per non-empty category
+  in canonical order a `\n` + `Capitalized:` header; each entry `- msg`; ` (`
+  + comma-joined `[#PR](REPO/pull/PR)` / `[#ISSUE](REPO/issues/ISSUE)` + `)`
+  when refs exist; lines joined by `\n`.
+
+- `func RenderMerged(merged map[string][]MergedEntry) string`
+  — same layout, but each entry line is prefixed with its version:
+  `- v0.4.0: msg ([#8](…))`.
+
+`REPO_URL` constant mirrors the Python `https://github.com/bernd/vibepit`.
+
+### Tests
+
+- **Consistency test (key safeguard):** for every committed
+  `docs/content/releases/*.json`, assert
+  `RenderChanges(meta.Changes) == meta.Changelog`. Pins the Go renderer to the
+  Python generator; catches drift on either side. (Versions without `changes`
+  are skipped — there is nothing to compare.)
+- Table-driven tests for `ReleasesBetween` (current in/below/above range, dev
+  build, equal-to-target, empty index), `MergeChanges` (order, concat,
+  multi-category), `formatEntry`/render (pr only, issue only, both, none),
+  `RenderMerged` (version prefix placement).
+
+## CLI changes (`cmd/update.go`, channel path only)
+
+In `runBinaryUpdate`, after `ShouldUpdate` confirms an update and the target
+`meta` is fetched:
+
+1. Compute `rng := idx.ReleasesBetween(config.Version, idx.Latest)`.
+2. Decide what to display:
+   - **`len(rng) <= 1`** → render the target's `meta.Changes` with
+     `RenderChanges` (no prefix). Identical to today's output.
+   - **`len(rng) > 1`** → fetch metadata for each in-range version (reusing the
+     already-fetched target `meta`), `MergeChanges`, and render with
+     `RenderMerged` as one block.
+3. Label: `Changelog (v{current} → v{target}):` when more than one release is
+   spanned; plain `Changelog:` for the single-release case.
+
+The direct `--version` / `useVersion` path is unchanged (explicit single
+install).
+
+### Fallbacks (degrade, never block the update)
+
+- Installed version is a dev build / unparseable (`IsDevBuild`) → no computable
+  range → show the target's changelog only (today's behavior).
+- Any in-range version lacks structured `changes`, **or** a metadata fetch for
+  an in-range version fails → fall back to the target's rendered `changelog`
+  string. No silent partial merges.
+
+## Example output
+
+Updating 0.2.0 → 0.4.0:
+
+```
+Current version: 0.2.0
+Target version:  0.4.0 (2026-…)
+
+Changelog (v0.2.0 → v0.4.0):
+
+Fixed:
+- v0.4.0: Properly resolve the issue from 0.3.0 ([#21](…))
+- v0.3.0: Partial fix for race ([#14](…))
+
+Added:
+- v0.4.0: New preset
+- v0.2.0: extra-hosts option ([#11](…))
+```
+
+## Verification
+
+- `make test` (selfupdate unit tests, including the consistency test).
+- Manual: regenerate the committed JSONs via `--backfill-changes`, confirm
+  `make test` passes and the JSON diffs only add `changes`.
+- Generator output validated indirectly by the Go consistency test against the
+  committed JSONs (the repo has no Python test harness).

--- a/selfupdate/changelog.go
+++ b/selfupdate/changelog.go
@@ -1,0 +1,93 @@
+package selfupdate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// repoURL is the GitHub repository used to build changelog PR/issue links.
+// Must match REPO_URL in .github/scripts/generate-release-metadata.py.
+const repoURL = "https://github.com/bernd/vibepit"
+
+// changelogCategories is the canonical render order for changelog sections.
+// Must match CHANGELOG_CATEGORIES in the metadata generator.
+var changelogCategories = []string{"added", "changed", "fixed", "deprecated", "removed", "security"}
+
+// refSuffix renders the trailing " ([#pr](...), [#issue](...))" for an entry,
+// or "" when it has no references.
+func refSuffix(e ChangelogEntry) string {
+	var refs []string
+	if e.PR != "" {
+		refs = append(refs, fmt.Sprintf("[#%s](%s/pull/%s)", e.PR, repoURL, e.PR))
+	}
+	if e.Issue != "" {
+		refs = append(refs, fmt.Sprintf("[#%s](%s/issues/%s)", e.Issue, repoURL, e.Issue))
+	}
+	if len(refs) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(refs, ", ") + ")"
+}
+
+// formatEntry renders a single entry line without a version prefix.
+func formatEntry(e ChangelogEntry) string {
+	return "- " + e.Msg + refSuffix(e)
+}
+
+// capitalizeCategory upper-cases the first letter of a category name to match
+// Python's str.capitalize() for these single lowercase words.
+func capitalizeCategory(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// renderSections renders the per-category blocks shared by RenderChanges and
+// RenderMerged: a "\nCategory:" header per non-empty category in canonical
+// order, then one line per entry as produced by line. Categories are visited
+// in changelogCategories order so output matches the Python generator.
+func renderSections[E any](sections map[string][]E, line func(E) string) string {
+	var lines []string
+	for _, cat := range changelogCategories {
+		entries := sections[cat]
+		if len(entries) == 0 {
+			continue
+		}
+		lines = append(lines, "\n"+capitalizeCategory(cat)+":")
+		for _, e := range entries {
+			lines = append(lines, line(e))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// RenderChanges renders a single version's structured changes to the same text
+// the Python generator produces for the rendered "changelog" field. No version
+// prefix is added.
+func RenderChanges(changes map[string][]ChangelogEntry) string {
+	return renderSections(changes, formatEntry)
+}
+
+// MergeChanges concatenates the structured changes of multiple releases by
+// category, tagging each entry with its source version. metas must be ordered
+// newest-first so that the newest release's entries lead each category.
+func MergeChanges(metas []*VersionMetadata) map[string][]MergedEntry {
+	merged := make(map[string][]MergedEntry)
+	for _, m := range metas {
+		for cat, entries := range m.Changes {
+			for _, e := range entries {
+				merged[cat] = append(merged[cat], MergedEntry{Entry: e, Version: m.Version})
+			}
+		}
+	}
+	return merged
+}
+
+// RenderMerged renders merged changes as a single block, prefixing every entry
+// with its source version (e.g. "- v0.4.0: ...").
+func RenderMerged(merged map[string][]MergedEntry) string {
+	return renderSections(merged, func(m MergedEntry) string {
+		return "- v" + m.Version + ": " + m.Entry.Msg + refSuffix(m.Entry)
+	})
+}

--- a/selfupdate/changelog_test.go
+++ b/selfupdate/changelog_test.go
@@ -1,0 +1,118 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionMetadataChangesParsing(t *testing.T) {
+	data := `{
+		"version": "0.3.0",
+		"timestamp": "2026-06-09T00:04:34+02:00",
+		"changelog": "\nAdded:\n- Thing",
+		"changes": {
+			"added": [{"msg": "Thing"}],
+			"fixed": [{"msg": "Bug", "pr": "8"}]
+		},
+		"assets": []
+	}`
+	var meta VersionMetadata
+	require.NoError(t, json.Unmarshal([]byte(data), &meta))
+
+	require.Len(t, meta.Changes["added"], 1)
+	assert.Equal(t, "Thing", meta.Changes["added"][0].Msg)
+	assert.Empty(t, meta.Changes["added"][0].PR)
+
+	require.Len(t, meta.Changes["fixed"], 1)
+	assert.Equal(t, "Bug", meta.Changes["fixed"][0].Msg)
+	assert.Equal(t, "8", meta.Changes["fixed"][0].PR)
+}
+
+func TestRenderChanges(t *testing.T) {
+	changes := map[string][]ChangelogEntry{
+		"added": {
+			{Msg: "Plain feature"},
+			{Msg: "Feature with PR", PR: "11"},
+		},
+		"fixed": {
+			{Msg: "Bug with issue", Issue: "5"},
+			{Msg: "Bug with both", PR: "8", Issue: "9"},
+		},
+	}
+	want := "\nAdded:\n" +
+		"- Plain feature\n" +
+		"- Feature with PR ([#11](https://github.com/bernd/vibepit/pull/11))\n" +
+		"\nFixed:\n" +
+		"- Bug with issue ([#5](https://github.com/bernd/vibepit/issues/5))\n" +
+		"- Bug with both ([#8](https://github.com/bernd/vibepit/pull/8), [#9](https://github.com/bernd/vibepit/issues/9))"
+	assert.Equal(t, want, RenderChanges(changes))
+}
+
+func TestRenderChangesEmpty(t *testing.T) {
+	assert.Equal(t, "", RenderChanges(map[string][]ChangelogEntry{}))
+	assert.Equal(t, "", RenderChanges(nil))
+}
+
+func TestRenderChangesMatchesReleaseJSON(t *testing.T) {
+	paths, err := filepath.Glob("../docs/content/releases/*.json")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+
+	checked := 0
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if base == "stable.json" || base == "prerelease.json" {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		require.NoError(t, err, p)
+
+		var meta VersionMetadata
+		require.NoError(t, json.Unmarshal(data, &meta), p)
+
+		if len(meta.Changes) == 0 {
+			continue
+		}
+		assert.Equal(t, meta.Changelog, RenderChanges(meta.Changes),
+			"RenderChanges output drifted from the rendered changelog in %s", base)
+		checked++
+	}
+	assert.Positive(t, checked, "expected at least one release JSON with a changes field")
+}
+
+func TestMergeChangesAndRenderMerged(t *testing.T) {
+	newer := &VersionMetadata{
+		Version: "0.4.0",
+		Changes: map[string][]ChangelogEntry{
+			"fixed": {{Msg: "Resolve issue from 0.3.0", PR: "21"}},
+			"added": {{Msg: "New preset"}},
+		},
+	}
+	older := &VersionMetadata{
+		Version: "0.3.0",
+		Changes: map[string][]ChangelogEntry{
+			"fixed": {{Msg: "Partial fix", PR: "14"}},
+			"added": {{Msg: "extra-hosts option", PR: "11"}},
+		},
+	}
+
+	// Passed newest-first.
+	merged := MergeChanges([]*VersionMetadata{newer, older})
+
+	require.Len(t, merged["fixed"], 2)
+	assert.Equal(t, "0.4.0", merged["fixed"][0].Version)
+	assert.Equal(t, "0.3.0", merged["fixed"][1].Version)
+
+	want := "\nAdded:\n" +
+		"- v0.4.0: New preset\n" +
+		"- v0.3.0: extra-hosts option ([#11](https://github.com/bernd/vibepit/pull/11))\n" +
+		"\nFixed:\n" +
+		"- v0.4.0: Resolve issue from 0.3.0 ([#21](https://github.com/bernd/vibepit/pull/21))\n" +
+		"- v0.3.0: Partial fix ([#14](https://github.com/bernd/vibepit/pull/14))"
+	assert.Equal(t, want, RenderMerged(merged))
+}

--- a/selfupdate/releases.go
+++ b/selfupdate/releases.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -29,10 +32,26 @@ type ReleaseEntry struct {
 
 // VersionMetadata represents a per-version metadata file (e.g., 0.2.0.json).
 type VersionMetadata struct {
-	Version   string  `json:"version"`
-	Timestamp string  `json:"timestamp"`
-	Changelog string  `json:"changelog"`
-	Assets    []Asset `json:"assets"`
+	Version   string                      `json:"version"`
+	Timestamp string                      `json:"timestamp"`
+	Changelog string                      `json:"changelog"`
+	Changes   map[string][]ChangelogEntry `json:"changes,omitempty"`
+	Assets    []Asset                     `json:"assets"`
+}
+
+// ChangelogEntry is a single structured changelog entry parsed from a
+// docs/changelogs/{version}.yml file.
+type ChangelogEntry struct {
+	Msg   string `json:"msg"`
+	PR    string `json:"pr,omitempty"`
+	Issue string `json:"issue,omitempty"`
+}
+
+// MergedEntry is a ChangelogEntry tagged with the release version it came
+// from, used when merging changelogs across multiple releases.
+type MergedEntry struct {
+	Entry   ChangelogEntry
+	Version string
 }
 
 // Asset represents a platform-specific release asset.
@@ -52,6 +71,56 @@ func (m *VersionMetadata) FindAsset(os, arch string) (*Asset, error) {
 		}
 	}
 	return nil, fmt.Errorf("no asset found for %s/%s", os, arch)
+}
+
+// ReleasesBetween returns the releases newer than current and no newer than
+// target (current < v <= target), sorted newest-first. The caller must ensure
+// current is a valid release version; an invalid semver sorts below all
+// releases and would match everything.
+func (idx *ChannelIndex) ReleasesBetween(current, target string) []ReleaseEntry {
+	vCurrent, vTarget := addV(current), addV(target)
+	var out []ReleaseEntry
+	for _, r := range idx.Releases {
+		if semver.Compare(vCurrent, addV(r.Version)) < 0 &&
+			semver.Compare(addV(r.Version), vTarget) <= 0 {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return semver.Compare(addV(out[i].Version), addV(out[j].Version)) > 0
+	})
+	return out
+}
+
+// OtherChannel returns the opposite release channel.
+func OtherChannel(channel string) string {
+	if channel == ChannelPrerelease {
+		return ChannelStable
+	}
+	return ChannelPrerelease
+}
+
+// CombineReleases returns the union of the two indexes' release entries,
+// deduplicated by version (first occurrence wins). Stable and prerelease
+// releases live in separate indexes, so a cross-channel update needs both to
+// see every release it skipped; a single index alone would omit the other
+// channel's intervening releases. nil indexes are ignored.
+func CombineReleases(a, b *ChannelIndex) []ReleaseEntry {
+	seen := make(map[string]bool)
+	var out []ReleaseEntry
+	for _, idx := range []*ChannelIndex{a, b} {
+		if idx == nil {
+			continue
+		}
+		for _, r := range idx.Releases {
+			if seen[r.Version] {
+				continue
+			}
+			seen[r.Version] = true
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // Client fetches release metadata from vibepit.dev.

--- a/selfupdate/releases_test.go
+++ b/selfupdate/releases_test.go
@@ -194,3 +194,84 @@ func TestEndToEndUpdateFlow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "abc", asset.SHA256)
 }
+
+func TestReleasesBetween(t *testing.T) {
+	idx := &ChannelIndex{
+		Releases: []ReleaseEntry{
+			{Version: "0.4.0"}, {Version: "0.3.0"},
+			{Version: "0.2.0"}, {Version: "0.1.0"},
+		},
+	}
+	tests := []struct {
+		name            string
+		current, target string
+		want            []string
+	}{
+		{"spans multiple", "0.1.0", "0.4.0", []string{"0.4.0", "0.3.0", "0.2.0"}},
+		{"single step", "0.3.0", "0.4.0", []string{"0.4.0"}},
+		{"current equals target", "0.4.0", "0.4.0", nil},
+		{"current above latest", "0.5.0", "0.4.0", nil},
+		{"target excludes newer", "0.1.0", "0.3.0", []string{"0.3.0", "0.2.0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := idx.ReleasesBetween(tt.current, tt.target)
+			var versions []string
+			for _, r := range got {
+				versions = append(versions, r.Version)
+			}
+			assert.Equal(t, tt.want, versions)
+		})
+	}
+}
+
+func TestReleasesBetweenSortsNewestFirst(t *testing.T) {
+	idx := &ChannelIndex{
+		Releases: []ReleaseEntry{
+			{Version: "0.2.0"}, {Version: "0.4.0"}, {Version: "0.3.0"},
+		},
+	}
+	got := idx.ReleasesBetween("0.1.0", "0.4.0")
+	require.Len(t, got, 3)
+	assert.Equal(t, "0.4.0", got[0].Version)
+	assert.Equal(t, "0.3.0", got[1].Version)
+	assert.Equal(t, "0.2.0", got[2].Version)
+}
+
+func TestOtherChannel(t *testing.T) {
+	assert.Equal(t, ChannelStable, OtherChannel(ChannelPrerelease))
+	assert.Equal(t, ChannelPrerelease, OtherChannel(ChannelStable))
+}
+
+func TestCombineReleases(t *testing.T) {
+	stable := &ChannelIndex{Releases: []ReleaseEntry{
+		{Version: "0.4.0"}, {Version: "0.3.0"},
+	}}
+	pre := &ChannelIndex{Releases: []ReleaseEntry{
+		{Version: "0.4.0-rc.1"}, {Version: "0.3.0-rc.1"},
+	}}
+
+	t.Run("union of both channels", func(t *testing.T) {
+		got := CombineReleases(stable, pre)
+		versions := make([]string, len(got))
+		for i, r := range got {
+			versions[i] = r.Version
+		}
+		assert.ElementsMatch(t, []string{"0.4.0", "0.3.0", "0.4.0-rc.1", "0.3.0-rc.1"}, versions)
+	})
+
+	t.Run("deduplicates by version", func(t *testing.T) {
+		dup := &ChannelIndex{Releases: []ReleaseEntry{{Version: "0.4.0"}, {Version: "0.5.0"}}}
+		got := CombineReleases(stable, dup)
+		versions := make([]string, len(got))
+		for i, r := range got {
+			versions[i] = r.Version
+		}
+		assert.ElementsMatch(t, []string{"0.4.0", "0.3.0", "0.5.0"}, versions)
+	})
+
+	t.Run("ignores nil index", func(t *testing.T) {
+		got := CombineReleases(stable, nil)
+		assert.Len(t, got, 2)
+	})
+}


### PR DESCRIPTION
Previously `update` displayed only the target release's changelog, so a user several releases behind never saw the notes for the releases in between. The update now renders a single merged changelog covering every skipped release, with each entry prefixed by its source version.