### PR TITLE
Add /etc/gitconfig to sandbox to rewrite SSH GitHub access to HTTPS

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -117,6 +117,7 @@ RUN install -d -o root -g root -m 0755 /etc/vibepit \
   && install -d -o root -g root -m 0755 /etc/vibepit/sshd \
   && install -d -o root -g root -m 0755 /opt/vibepit
 COPY config/bashrc /etc/vibepit/bashrc
+COPY config/gitconfig /etc/gitconfig
 COPY config/tmux.conf /etc/vibepit/tmux.conf
 COPY lib.sh /etc/vibepit/lib.sh
 

--- a/image/config/gitconfig
+++ b/image/config/gitconfig
@@ -1,0 +1,8 @@
+# vim: ft=gitconfig
+
+# Vibepit Git settings
+
+# The sandbox only reaches GitHub over HTTPS through the filtering proxy.
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+	insteadOf = ssh://git@github.com/


### PR DESCRIPTION
SSH traffic is not allowed inside the sandbox.